### PR TITLE
Update requirements for CVE-2017-7308 and fix missing `sysctl` directives

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -658,7 +658,7 @@ EOF
 
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-9793]${txtrst} SO_{SND|RCV}BUFFORCE
-Reqs: pkg=linux-kernel,ver>=3.11,ver<4.8.14,CONFIG_USER_NS=y,kernel.unprivileged_userns_clone==1
+Reqs: pkg=linux-kernel,ver>=3.11,ver<4.8.14,CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1
 Tags:
 analysis-url: https://github.com/xairy/kernel-exploits/tree/master/CVE-2016-9793
 src-url: https://raw.githubusercontent.com/xairy/kernel-exploits/master/CVE-2016-9793/poc.c
@@ -670,7 +670,7 @@ EOF
 
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2017-6074]${txtrst} dccp
-Reqs: pkg=linux-kernel,ver>=2.6.18,ver<=4.9.11,CONFIG_IP_DCCP=[my],CONFIG_USER_NS=y,kernel.unprivileged_userns_clone==1
+Reqs: pkg=linux-kernel,ver>=2.6.18,ver<=4.9.11,CONFIG_IP_DCCP=[my],CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1
 Tags: ubuntu=16.04
 analysis-url: http://www.openwall.com/lists/oss-security/2017/02/22/3
 Comments: Requires Kernel be built with CONFIG_IP_DCCP enabled. Includes partial SMEP/SMAP bypass
@@ -681,7 +681,7 @@ EOF
 
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2017-7308]${txtrst} af_packet
-Reqs: pkg=linux-kernel,ver>=3.2,ver<=4.10.6,CONFIG_USER_NS=y,kernel.unprivileged_userns_clone==1
+Reqs: pkg=linux-kernel,ver>=3.2,ver<=4.10.6,CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1
 Tags: ubuntu=16.04(kernel:4.8.0-41)
 analysis-url: https://googleprojectzero.blogspot.com/2017/05/exploiting-linux-kernel-via-packet.html
 src-url: https://raw.githubusercontent.com/xairy/kernel-exploits/master/CVE-2017-7308/poc.c
@@ -693,7 +693,7 @@ EOF
 
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2017-1000112]${txtrst} NETIF_F_UFO
-Reqs: pkg=linux-kernel,ver>=4.4,ver<=4.13,CONFIG_USER_NS=y,kernel.unprivileged_userns_clone==1
+Reqs: pkg=linux-kernel,ver>=4.4,ver<=4.13,CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1
 Tags: ubuntu=14.04(kernel:4.4.0-*)|16.04(kernel:4.8.0-*)
 analysis-url: http://www.openwall.com/lists/oss-security/2017/08/13/1
 src-url: https://raw.githubusercontent.com/xairy/kernel-exploits/master/CVE-2017-1000112/poc.c

--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -670,7 +670,7 @@ EOF
 
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2017-6074]${txtrst} dccp
-Reqs: pkg=linux-kernel,ver>=2.6.18,ver<=4.9.11,CONFIG_IP_DCCP=[my]
+Reqs: pkg=linux-kernel,ver>=2.6.18,ver<=4.9.11,CONFIG_IP_DCCP=[my],CONFIG_USER_NS=y,kernel.unprivileged_userns_clone==1
 Tags: ubuntu=16.04
 analysis-url: http://www.openwall.com/lists/oss-security/2017/02/22/3
 Comments: Requires Kernel be built with CONFIG_IP_DCCP enabled. Includes partial SMEP/SMAP bypass


### PR DESCRIPTION
The exploit sandbox setup fails unless `CONFIG_USER_NS=y,kernel.unprivileged_userns_clone==1`

```
unshare(CLONE_NEWUSER): Operation not permitted
```

The exploit performs the sandbox setup, regardless of whether `#define SMEP_SMAP_BYPASS` is enabled.
