### PR TITLE
Add core_pattern checks for racebrt and newpid

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -787,7 +787,7 @@ EOF
 
 EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-1862]${txtrst} newpid (abrt)
-Reqs: pkg=abrt
+Reqs: pkg=abrt,cmd:grep -qi abrt /proc/sys/kernel/core_pattern
 Tags: fedora=20
 analysis-url: http://openwall.com/lists/oss-security/2015/04/14/4
 src-url: https://gist.githubusercontent.com/taviso/0f02c255c13c5c113406/raw/eafac78dce51329b03bea7167f1271718bee4dcc/newpid.c
@@ -797,8 +797,8 @@ EOF
 
 EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-3315]${txtrst} raceabrt
-Reqs: pkg=abrt
-Tags: fedora=21,RHEL=7
+Reqs: pkg=abrt,cmd:grep -qi abrt /proc/sys/kernel/core_pattern
+Tags: fedora=19|20|21,RHEL=7
 analysis-url: http://seclists.org/oss-sec/2015/q2/130
 src-url: https://gist.githubusercontent.com/taviso/fe359006836d6cd1091e/raw/32fe8481c434f8cad5bcf8529789231627e5074c/raceabrt.c
 exploit-db: 36747
@@ -807,7 +807,7 @@ EOF
 
 EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-1318]${txtrst} newpid (apport)
-Reqs: pkg=apport,ver>=2.13,ver<=2.17
+Reqs: pkg=apport,ver>=2.13,ver<=2.17,cmd:grep -qi apport /proc/sys/kernel/core_pattern
 Tags: ubuntu=14.04
 analysis-url: http://openwall.com/lists/oss-security/2015/04/14/4
 src-url: https://gist.githubusercontent.com/taviso/0f02c255c13c5c113406/raw/eafac78dce51329b03bea7167f1271718bee4dcc/newpid.c
@@ -817,7 +817,7 @@ EOF
 
 EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-1318]${txtrst} newpid (apport) 2
-Reqs: pkg=apport,ver>=2.13,ver<=2.17
+Reqs: pkg=apport,ver>=2.13,ver<=2.17,cmd:grep -qi apport /proc/sys/kernel/core_pattern
 Tags: ubuntu=14.04.2
 analysis-url: http://openwall.com/lists/oss-security/2015/04/14/4
 exploit-db: 36782


### PR DESCRIPTION
Apport on Ubuntu and ABRT on Fedora are vulnerable
only when specified as the system crash handler.