### PR TITLE
Add support for Fedora

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -1156,6 +1156,7 @@ parseUname() {
     OS=""
     echo "$uname" | grep -q -i 'deb' && OS="debian"
     echo "$uname" | grep -q -i 'ubuntu' && OS="ubuntu"
+    echo "$uname" | grep -q -i '\.fc' && OS="fedora"
     echo "$uname" | grep -q -i '\.el' && OS="RHEL"
 
     # 'uname -a' output doesn't contain distribution number (at least not in case of all distros)
@@ -1185,7 +1186,7 @@ getPkgList() {
 
     elif [ "$distro" = "debian" -o "$distro" = "ubuntu" ]; then
         PKG_LIST=$(dpkg -l | awk '{print $2"-"$3}' | sed 's/:amd64//g')
-    elif [ "$distro" = "RHEL" ]; then
+    elif [ "$distro" = "RHEL" -o "$distro" = "fedora" ]; then
         PKG_LIST=$(rpm -qa)
     else
         # packages listing not available


### PR DESCRIPTION
Add support for Fedora - Fix #10

Output for Fedora 20 shown below.

### Before Patch

```
[user@localhost linux-exploit-suggester]$ ./linux-exploit-suggester.sh  --userspace-only


Available information:

Kernel version: 3.19.8
Architecture: x86_64
Distribution: fedora
Distribution version: 20
Additional checks (CONFIG_*, sysctl entries, custom Bash commands): performed
Package listing: N/A

Searching among:

0 kernel space exploits
0 user space exploits

Possible Exploits:

```


### After Patch


```
[user@localhost linux-exploit-suggester]$ ./linux-exploit-suggester.sh --userspace-only

Available information:

Kernel version: 3.19.8
Architecture: x86_64
Distribution: fedora
Distribution version: 20
Additional checks (CONFIG_*, sysctl entries, custom Bash commands): performed
Package listing: from current OS

Searching among:

0 kernel space exploits
31 user space exploits

Possible Exploits:

[+] [CVE-2015-1862] newpid (abrt)

   Details: http://openwall.com/lists/oss-security/2015/04/14/4
   Tags: [fedora=20]
   Download URL: https://gist.githubusercontent.com/taviso/0f02c255c13c5c113406/raw/eafac78dce51329b03bea7167f1271718bee4dcc/newpid.c

[+] [CVE-2015-3315] raceabrt

   Details: http://seclists.org/oss-sec/2015/q2/130
   Tags: fedora=21,RHEL=7
   Download URL: https://gist.githubusercontent.com/taviso/fe359006836d6cd1091e/raw/32fe8481c434f8cad5bcf8529789231627e5074c/raceabrt.c

[+] [CVE-2015-1815] setroubleshoot

   Details: https://www.exploit-db.com/exploits/36564/
   Tags: fedora=21
   Download URL: https://www.exploit-db.com/download/36564

[+] [CVE-2015-3246] userhelper

   Details: https://www.qualys.com/2015/07/23/cve-2015-3245-cve-2015-3246/cve-2015-3245-cve-2015-3246.txt
   Tags: RHEL<=7
   Download URL: https://www.exploit-db.com/download/37706

[+] [CVE-2016-4989] setroubleshoot 2

   Details: https://c-skills.blogspot.com/2016/06/lets-feed-attacker-input-to-sh-c-to-see.html
   Tags: RHEL=6|7
   Download URL: https://github.com/stealth/troubleshooter/blob/master/straight-shooter.c

[+] [CVE-2017-1000367] Sudoer-to-root

   Details: https://www.sudo.ws/alerts/linux_tty.html
   Tags: RHEL=7(sudo:1.8.6p7)
   Download URL: https://www.qualys.com/2017/05/30/cve-2017-1000367/linux_sudo_cve-2017-1000367.c
   Comments: Needs to be sudoer. Works only on SELinux enabled systems

[+] [CVE-2017-1000367] sudopwn

   Details: https://www.sudo.ws/alerts/linux_tty.html
   Download URL: https://raw.githubusercontent.com/c0d3z3r0/sudo-CVE-2017-1000367/master/sudopwn.c
   Comments: Needs to be sudoer. Works only on SELinux enabled systems

[+] [CVE-2017-1000366,CVE-2017-1000379] linux_ldso_hwcap_64

   Details: https://www.qualys.com/2017/06/19/stack-clash/stack-clash.txt
   Tags: debian=7.7|8.5|9.0,ubuntu=14.04.2|16.04.2|17.04,fedora=22|25,centos=7.3.1611
   Download URL: https://www.qualys.com/2017/06/19/stack-clash/linux_ldso_hwcap_64.c
   Comments: Uses "Stack Clash" technique, works against most SUID-root binaries

[+] [CVE-2018-1000001] RationalLove

   Details: https://www.halfdog.net/Security/2017/LibcRealpathBufferUnderflow/
   Tags: debian=9(glibc:2.24-11+deb9u1),ubuntu=16.04.3(glibc:2.23-0ubuntu9)
   Download URL: https://www.halfdog.net/Security/2017/LibcRealpathBufferUnderflow/RationalLove.c
   Comments: kernel.unprivileged_userns_clone=1 required


```