### PR TITLE
Fix `straight-shooter` download `src-url`

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -920,7 +920,7 @@ Name: ${txtgrn}[CVE-2016-4989]${txtrst} setroubleshoot 2
 Reqs: pkg=setroubleshoot
 Tags: RHEL=6|7
 analysis-url: https://c-skills.blogspot.com/2016/06/lets-feed-attacker-input-to-sh-c-to-see.html
-src-url: https://github.com/stealth/troubleshooter/blob/master/straight-shooter.c
+src-url: https://github.com/stealth/troubleshooter/raw/master/straight-shooter.c
 exploit-db:
 EOF
 )


### PR DESCRIPTION
This PR fixes the `straight-shooter.c` download `src-url`.

The GitHub `blob` URL returns HTML, where as the `raw` URL returns the source which is `wget` friendly.

The `straight-shooter.c` exploit `src-url` appears to be the only `blob` URL. Other exploits use the appropriate `raw` URL.

```
$ grep src-url linux-exploit-suggester.sh  | grep github | fgrep -v raw
src-url: https://github.com/stealth/troubleshooter/blob/master/straight-shooter.c
```