### PR TITLE
Update chocobo_root requirements

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -644,9 +644,10 @@ EOF
 
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-8655]${txtrst} chocobo_root
-Reqs: pkg=linux-kernel,ver>=4.4.0,ver<4.9
+Reqs: pkg=linux-kernel,ver>=4.4.0,ver<4.9,CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1
 Tags: ubuntu=16.04|14.04
 analysis-url: http://www.openwall.com/lists/oss-security/2016/12/06/1
+Comments: CAP_NET_RAW capability is needed OR CONFIG_USER_NS=y needs to be enabled
 exploit-db: 40871
 author: rebel
 EOF


### PR DESCRIPTION
CAP_NET_RAW capability is needed OR CONFIG_USER_NS=y needs to be enabled.

> To create AF_PACKET sockets you need CAP_NET_RAW in your network
namespace, which can be acquired by unprivileged processes on
systems where unprivileged namespaces are enabled (Ubuntu, Fedora, etc).
It can be triggered from within containers to compromise the host kernel.
On Android, processes with gid=3004/AID_NET_RAW are able to create
AF_PACKET sockets (mediaserver) and can trigger the bug.

~ http://www.openwall.com/lists/oss-security/2016/12/06/1
