### PR TITLE
Update espfix64_NMI requirements

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -533,7 +533,7 @@ EOF
 
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-3290]${txtrst} espfix64_NMI
-Reqs: pkg=linux-kernel,ver>=3.13,x86_64
+Reqs: pkg=linux-kernel,ver>=3.13,ver<4.1.6,x86_64
 Tags: 
 analysis-url: http://www.openwall.com/lists/oss-security/2015/08/04/8
 exploit-db: 37722


### PR DESCRIPTION
Linux kernel before 4.1.6

> arch/x86/entry/entry_64.S in the Linux kernel before 4.1.6 on the x86_64 platform improperly relies on espfix64 during nested NMI processing, which allows local users to gain privileges by triggering an NMI within a certain instruction window. 

~ https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-3290