### PR TITLE
Update keyring requirements

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -579,7 +579,7 @@ EOF
 
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-0728]${txtrst} keyring
-Reqs: pkg=linux-kernel,ver>=3.10
+Reqs: pkg=linux-kernel,ver>=3.10,ver<4.4.1
 Tags:
 analysis-url: http://perception-point.io/2016/01/14/analysis-and-exploitation-of-a-linux-kernel-vulnerability-cve-2016-0728/
 exploit-db: 40003


### PR DESCRIPTION
Linux kernel before 4.4.1

> The join_session_keyring function in security/keys/process_keys.c in the Linux kernel before 4.4.1 mishandles object references in a certain error case, which allows local users to gain privileges or cause a denial of service (integer overflow and use-after-free) via crafted keyctl commands. 

~ https://cve.mitre.org/cgi-bin/cvename.cgi?name=cve-2016-0728