### PR TITLE
Update PPPoL2TP requirements

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -507,7 +507,7 @@ EOF
 
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2014-4943]${txtrst} PPPoL2TP ${bldblu}(DoS)${txtrst}
-Reqs: pkg=linux-kernel,ver>=3.15
+Reqs: pkg=linux-kernel,ver>=3.2,ver<=3.15.6
 Tags: 
 analysis-url: https://cyseclabs.com/page?n=01102015
 exploit-db: 36267


### PR DESCRIPTION
Linux kernel through 3.15.6

> The PPPoL2TP feature in net/l2tp/l2tp_ppp.c in the Linux kernel through 3.15.6 allows local users to gain privileges by leveraging data-structure differences between an l2tp socket and an inet socket. 

~ https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-4943

> #define TARGET_KERNEL_MIN "3.2.0"
> #define TARGET_KERNEL_MAX "3.15.6"
> #define EXPLOIT_NAME "cve-2014-4943"

~ https://www.exploit-db.com/exploits/36267/
