### PR TITLE
Update udev exploit requirements

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -736,7 +736,7 @@ EOF
 
 EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2009-1185]${txtrst} udev
-Reqs: pkg=udev
+Reqs: pkg=udev,cmd:[[ -f /etc/udev/rules.d/95-udev-late.rules || -f /lib/udev/rules.d/95-udev-late.rules ]]
 Tags: ubuntu=8.10|9.04
 exploit-db: 8572
 Comments: Version<1.4.1 vulnerable but distros use own versioning scheme. Manual verification needed 


### PR DESCRIPTION
Exploit requires either of these rules to exist:

* /etc/udev/rules.d/95-udev-late.rules
* /lib/udev/rules.d/95-udev-late.rules