### PR TITLE
Update tags for userhelper

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -858,7 +858,7 @@ EOF
 EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-3246]${txtrst} userhelper
 Reqs: pkg=libuser,ver<=0.60
-Tags: RHEL<=7
+Tags: RHEL<=7,centos<=7,fedora<=22
 analysis-url: https://www.qualys.com/2015/07/23/cve-2015-3245-cve-2015-3246/cve-2015-3245-cve-2015-3246.txt 
 exploit-db: 37706
 EOF


### PR DESCRIPTION
`roothelper.c` tested on libuser versions:

* 0.56.13-4.el6 on CentOS 6.0 (x86_64)
* 0.56.13-5.el6 on CentOS 6.5 (x86_64)
* 0.60-5.el7 on CentOS 7.1-1503 (x86_64)
* 0.56.16-1.fc13 on Fedora 13 (i686)
* 0.59-1.fc19 on Fedora Desktop 19 (x86_64)
* 0.60-6.fc21 on Fedora Desktop 21 (x86_64)
* 0.56.13-5.el6 on Red Hat 6.6 (x86_64)
* 0.60-5.el7 on Red Hat 7.0 (x86_64)