### PR TITLE
Change kernel-exploits.com URLs to archive.org

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -284,7 +284,7 @@ Reqs: pkg=linux-kernel,ver>=2.6.26,ver<=2.6.34
 Tags: debian=6,ubuntu=10.04|10.10
 bin-url: https://web.archive.org/web/20111103042904/http://tarantula.by.ru/localroot/2.6.x/kmod2
 bin-url: https://web.archive.org/web/20111103042904/http://tarantula.by.ru/localroot/2.6.x/ptrace-kmod
-bin-url: https://www.kernel-exploits.com/media/ptrace_kmod2-64
+bin-url: https://web.archive.org/web/20160602192641/https://www.kernel-exploits.com/media/ptrace_kmod2-64
 exploit-db: 15023
 EOF
 )
@@ -301,7 +301,7 @@ EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2010-2959]${txtrst} can_bcm
 Reqs: pkg=linux-kernel,ver>=2.6.18,ver<=2.6.36
 Tags: ubuntu=10.04
-bin-url: https://www.kernel-exploits.com/media/can_bcm
+bin-url: https://web.archive.org/web/20160602192641/https://www.kernel-exploits.com/media/can_bcm
 exploit-db: 14814
 EOF
 )
@@ -311,8 +311,8 @@ Name: ${txtgrn}[CVE-2010-3904]${txtrst} rds
 Reqs: pkg=linux-kernel,ver>=2.6.30,ver<=2.6.36
 Tags: debian=6,ubuntu=10.10|10.04|9.10,fedora=16
 analysis-url: http://www.securityfocus.com/archive/1/514379
-bin-url: https://www.kernel-exploits.com/media/rds
-bin-url: https://www.kernel-exploits.com/media/rds64
+bin-url: https://web.archive.org/web/20160602192641/https://www.kernel-exploits.com/media/rds
+bin-url: https://web.archive.org/web/20160602192641/https://www.kernel-exploits.com/media/rds64
 exploit-db: 15285
 EOF
 )
@@ -321,7 +321,7 @@ EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2010-3848,CVE-2010-3850,CVE-2010-4073]${txtrst} half_nelson
 Reqs: pkg=linux-kernel,ver>=2.6.0,ver<=2.6.36
 Tags: ubuntu=10.04|9.10
-bin-url: https://www.kernel-exploits.com/media/half-nelson3
+bin-url: http://web.archive.org/web/20160602192631/https://www.kernel-exploits.com/media/half-nelson3
 exploit-db: 17787
 EOF
 )
@@ -372,8 +372,8 @@ Reqs: pkg=linux-kernel,ver>=3.0.0,ver<=3.1.0
 Tags: ubuntu=10.04|11.10
 analysis-url: https://git.zx2c4.com/CVE-2012-0056/about/
 src-url: https://git.zx2c4.com/CVE-2012-0056/plain/mempodipper.c
-bin-url: https://www.kernel-exploits.com/media/memodipper
-bin-url: https://www.kernel-exploits.com/media/memodipper64
+bin-url: https://web.archive.org/web/20160602192631/https://www.kernel-exploits.com/media/memodipper
+bin-url: https://web.archive.org/web/20160602192631/https://www.kernel-exploits.com/media/memodipper64
 exploit-db: 18411
 EOF
 )
@@ -383,8 +383,8 @@ Name: ${txtgrn}[CVE-2012-0056,CVE-2010-3849,CVE-2010-3850]${txtrst} full-nelson
 Reqs: pkg=linux-kernel,ver>=2.6.0,ver<=2.6.36
 Tags: ubuntu=9.10|10.04|10.10,ubuntu=10.04.1
 src-url: http://vulnfactory.org/exploits/full-nelson.c
-bin-url: https://www.kernel-exploits.com/media/full-nelson
-bin-url: https://www.kernel-exploits.com/media/full-nelson64
+bin-url: https://web.archive.org/web/20160602192631/https://www.kernel-exploits.com/media/full-nelson
+bin-url: https://web.archive.org/web/20160602192631/https://www.kernel-exploits.com/media/full-nelson64
 exploit-db: 15704
 EOF
 )
@@ -406,8 +406,8 @@ Name: ${txtgrn}[CVE-2013-2094]${txtrst} perf_swevent
 Reqs: pkg=linux-kernel,ver>=2.6.32,ver<3.8.9
 Tags: RHEL=6,ubuntu=12.04
 analysis-url: http://timetobleed.com/a-closer-look-at-a-recent-privilege-escalation-bug-in-linux-cve-2013-2094/
-bin-url: https://www.kernel-exploits.com/media/perf_swevent
-bin-url: https://www.kernel-exploits.com/media/perf_swevent64
+bin-url: https://web.archive.org/web/20160602192631/https://www.kernel-exploits.com/media/perf_swevent
+bin-url: https://web.archive.org/web/20160602192631/https://www.kernel-exploits.com/media/perf_swevent64
 exploit-db: 26131
 EOF
 )
@@ -453,7 +453,7 @@ Name: ${txtgrn}[CVE-2014-0038]${txtrst} timeoutpwn
 Reqs: pkg=linux-kernel,ver>=3.4.0,ver<=3.13.1,CONFIG_X86_X32=y
 Tags: ubuntu=13.10
 analysis-url: http://blog.includesecurity.com/2014/03/exploit-CVE-2014-0038-x32-recvmmsg-kernel-vulnerablity.html
-bin-url: https://www.kernel-exploits.com/media/timeoutpwn64
+bin-url: https://web.archive.org/web/20160602192631/https://www.kernel-exploits.com/media/timeoutpwn64
 exploit-db: 31346
 Comments: CONFIG_X86_X32 needs to be enabled
 EOF
@@ -555,8 +555,8 @@ Name: ${txtgrn}[CVE-2015-1328]${txtrst} overlayfs
 Reqs: pkg=linux-kernel,ver>=3.13.0,ver<=3.19.0
 Tags: ubuntu=12.04|14.04|14.10|15.04
 analysis-url: http://seclists.org/oss-sec/2015/q2/717
-bin-url: https://www.kernel-exploits.com/media/ofs_32
-bin-url: https://www.kernel-exploits.com/media/ofs_64
+bin-url: https://web.archive.org/web/20160602192631/https://www.kernel-exploits.com/media/ofs_32
+bin-url: https://web.archive.org/web/20160602192631/https://www.kernel-exploits.com/media/ofs_64
 exploit-db: 37292
 EOF
 )


### PR DESCRIPTION
[kernel-exploits.com](https://kernel-exploits.com) no longer exists.

This PR replaces the `bin-url` for *kernel-exploits.com* exploits with their *archive.org* equivalent.

Another option would be to use some of the compiled binaries here: https://github.com/lucyoa/kernel-exploits