### PR TITLE
Update tags for userhelper and RDS exploits

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -309,7 +309,7 @@ EOF
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2010-3904]${txtrst} rds
 Reqs: pkg=linux-kernel,ver>=2.6.30,ver<=2.6.36
-Tags: debian=6,ubuntu=10.10|10.04|9.10,fedora=16
+Tags: debian=6,ubuntu=10.10|10.04|9.10,fedora=13
 analysis-url: http://www.securityfocus.com/archive/1/514379
 bin-url: https://web.archive.org/web/20160602192641/https://www.kernel-exploits.com/media/rds
 bin-url: https://web.archive.org/web/20160602192641/https://www.kernel-exploits.com/media/rds64
@@ -862,7 +862,7 @@ EOF
 EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-3246]${txtrst} userhelper
 Reqs: pkg=libuser,ver<=0.60
-Tags: RHEL<=7
+Tags: RHEL<=7,centos<=7,fedora<=22
 analysis-url: https://www.qualys.com/2015/07/23/cve-2015-3245-cve-2015-3246/cve-2015-3245-cve-2015-3246.txt 
 exploit-db: 37706
 EOF


### PR DESCRIPTION
**userhelper: `RHEL<=7,centos<=7,fedora<=22`**

`roothelper.c` tested on libuser versions:

* 0.56.13-4.el6 on CentOS 6.0 (x86_64)
* 0.56.13-5.el6 on CentOS 6.5 (x86_64)
* 0.60-5.el7 on CentOS 7.1-1503 (x86_64)
* 0.56.16-1.fc13 on Fedora 13 (i686)
* 0.59-1.fc19 on Fedora Desktop 19 (x86_64)
* 0.60-6.fc21 on Fedora Desktop 21 (x86_64)
* 0.56.13-5.el6 on Red Hat 6.6 (x86_64)
* 0.60-5.el7 on Red Hat 7.0 (x86_64)


**rds: `debian=6,ubuntu=10.10|10.04|9.10,fedora=13`**

The tag originally said `fedora=16` - but I have no idea where that came from. Fedora 16 was released in 2011 (after the bug was disclosed and patched in Oct 2010). Fedora 16 also makes use of 3.1 kernel.

I've verified the RDS exploit works on:

* Fedora 13 (i686) with kernel version 2.6.33.3-85.fc13.i686.PAE
* Ubuntu 10.04 (x86_64) with kernel version 2.6.32-21-generic
