### PR TITLE
Update eBPF_verifier (CVE-2017-16995)

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -700,11 +700,11 @@ EOF
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2017-16995]${txtrst} eBPF_verifier
 Reqs: pkg=linux-kernel,ver>=4.4,ver<=4.14.8,CONFIG_BPF_SYSCALL=y,sysctl:kernel.unprivileged_bpf_disabled!=1
-Tags: ubuntu=16.04.4{kernel:4.4.0-116}
-analysis-url: https://blog.aquasec.com/ebpf-vulnerability-cve-2017-16995-when-the-doorman-becomes-the-backdoor
+Tags: debian=9,fedora=25|26|27,ubuntu=14.04|16.04|17.04
+analysis-url: https://ricklarabee.blogspot.com/2018/07/ebpf-and-analysis-of-get-rekt-linux.html
 Comments: CONFIG_BPF_SYSCALL needs to be set && kernel.unprivileged_bpf_disabled != 1
-exploit-db: 44298
-author: Bruce Leidl
+exploit-db: 45010
+author: Rick Larabee
 EOF
 )
 


### PR DESCRIPTION
Update eBPF_verifier (CVE-2017-16995) exploit to use Rick Larabee's exploit.

Tested on:

  * Debian 9.0 kernel 4.9.0-3-amd64;
  * Deepin 15.5 kernel 4.9.0-deepin13-amd64;
  * ElementaryOS 0.4.1 kernel 4.8.0-52-generic;
  * Fedora 25 kernel 4.8.6-300.fc25.x86_64;
  * Fedora 26 kernel 4.11.8-300.fc26.x86_64;
  * Fedora 27 kernel 4.13.9-300.fc27.x86_64;
  * Gentoo 2.2 kernel 4.5.2-aufs-r1;
  * Linux Mint 17.3 kernel 4.4.0-89-generic;
  * Linux Mint 18.0 kernel 4.8.0-58-generic;
  * Linux Mint 18.3 kernel 4.13.0-16-generic;
  * Mageia 6 kernel 4.9.35-desktop-1.mga6;
  * Manjero 16.10 kernel 4.4.28-2-MANJARO;
  * Solus 3 kernel 4.12.7-11.current;
  * Ubuntu 14.04.1 kernel 4.4.0-89-generic;
  * Ubuntu 16.04.2 kernel 4.8.0-45-generic;
  * Ubuntu 16.04.3 kernel 4.10.0-28-generic;
  * Ubuntu 17.04 kernel 4.10.0-19-generic;
  * ZorinOS 12.1 kernel 4.8.0-39-generic.
