### PR TITLE
Add support for additional distros

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -1251,8 +1251,11 @@ parseUname() {
     OS=""
     echo "$uname" | grep -q -i 'deb' && OS="debian"
     echo "$uname" | grep -q -i 'ubuntu' && OS="ubuntu"
+    echo "$uname" | grep -q -i '\-deepin' && OS="deepin"
+    echo "$uname" | grep -q -i '\-MANJARO' && OS="manjaro"
     echo "$uname" | grep -q -i '\.fc' && OS="fedora"
     echo "$uname" | grep -q -i '\.el' && OS="RHEL"
+    echo "$uname" | grep -q -i '\.mga' && OS="mageia"
 
     # 'uname -a' output doesn't contain distribution number (at least not in case of all distros)
 }
@@ -1274,14 +1277,22 @@ getPkgList() {
         elif [ $(cat "$pkglist_file" | head -1 | grep -E '\.el[1-9]+\.') ]; then
             PKG_LIST=$(cat "$pkglist_file")
             OS="RHEL"
+        # fedora package listing file
+        elif [ $(cat "$pkglist_file" | head -1 | grep -E '\.fc[1-9]+') ]; then
+            PKG_LIST=$(cat "$pkglist_file")
+            OS="fedora"
+        # mageia package listing file
+        elif [ $(cat "$pkglist_file" | head -1 | grep -E '\.mga[1-9]+') ]; then
+            PKG_LIST=$(cat "$pkglist_file")
+            OS="mageia"
         # file not recognized - skipping
         else
             PKG_LIST=""
         fi
 
-    elif [ "$distro" = "debian" -o "$distro" = "ubuntu" ]; then
+    elif [ "$distro" = "debian" -o "$distro" = "ubuntu" -o "$distro" = "deepin" ]; then
         PKG_LIST=$(dpkg -l | awk '{print $2"-"$3}' | sed 's/:amd64//g')
-    elif [ "$distro" = "RHEL" -o "$distro" = "fedora" ]; then
+    elif [ "$distro" = "RHEL" -o "$distro" = "fedora" -o "$distro" = "mageia" ]; then
         PKG_LIST=$(rpm -qa)
     else
         # packages listing not available


### PR DESCRIPTION
This PR adds support for Manjaro, Mageia and Deepin Linux.

Bonus: It also improves the package detection for Fedora (slightly).

These changes have been tested with and without providing a package list with the `-p` argument.

The changes result in some code duplication in the package list parsing code `getPkgList()`, which should probably be refactored in the future. However, that's outside the scope of this PR, and I figured I'd leave that design decision up to you.

The Manjaro check is kind of useless, as Manjaro uses pacman for packages, which isn't supported by LES. But I left it in, as it's nice to see the pretty green text with the distro name.

I've written rudimentary parsing for `pacman -Qe` output, with support for arch and manjero, however I've left it out of this PR. I'll submit as a separate PR, after this PR is merged, to prevent conflicts.

