### PR TITLE
Add support for pacman packages

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -1251,6 +1251,7 @@ parseUname() {
     OS=""
     echo "$uname" | grep -q -i 'deb' && OS="debian"
     echo "$uname" | grep -q -i 'ubuntu' && OS="ubuntu"
+    echo "$uname" | grep -q -i '\-ARCH' && OS="arch"
     echo "$uname" | grep -q -i '\-deepin' && OS="deepin"
     echo "$uname" | grep -q -i '\-MANJARO' && OS="manjaro"
     echo "$uname" | grep -q -i '\.fc' && OS="fedora"

--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -1265,7 +1265,7 @@ getPkgList() {
     local distro=$1
     local pkglist_file=$2
     
-    # take package listing from provided file & detect if it's 'rpm -qa' listing or 'dpkg -l' or 'pacman -Qe' listing of not recognized listing
+    # take package listing from provided file & detect if it's 'rpm -qa' listing or 'dpkg -l' or 'pacman -Q' listing of not recognized listing
     if [ "$opt_pkglist_file" = "true" -a -e "$pkglist_file" ]; then
 
         # ubuntu/debian package listing file
@@ -1300,7 +1300,7 @@ getPkgList() {
     elif [ "$distro" = "RHEL" -o "$distro" = "fedora" -o "$distro" = "mageia" ]; then
         PKG_LIST=$(rpm -qa)
     elif [ "$distro" = "arch" -o "$distro" = "manjaro" ]; then
-        PKG_LIST=$(pacman -Qe | awk '{print $1"-"$2}')
+        PKG_LIST=$(pacman -Q | awk '{print $1"-"$2}')
     else
         # packages listing not available
         PKG_LIST=""

--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -1264,7 +1264,7 @@ getPkgList() {
     local distro=$1
     local pkglist_file=$2
     
-    # take package listing from provided file & detect if it's 'rpm -qa' listing or 'dpkg -l' listing or not recognized listing
+    # take package listing from provided file & detect if it's 'rpm -qa' listing or 'dpkg -l' or 'pacman -Qe' listing of not recognized listing
     if [ "$opt_pkglist_file" = "true" -a -e "$pkglist_file" ]; then
 
         # ubuntu/debian package listing file
@@ -1285,6 +1285,10 @@ getPkgList() {
         elif [ $(cat "$pkglist_file" | head -1 | grep -E '\.mga[1-9]+') ]; then
             PKG_LIST=$(cat "$pkglist_file")
             OS="mageia"
+        # pacman package listing file
+        elif [ "$(head -1 $pkglist_file | grep -E '\ [0-9]+\.')" ]; then
+            PKG_LIST=$(cat "$pkglist_file" | awk '{print $1"-"$2}')
+            OS="arch"
         # file not recognized - skipping
         else
             PKG_LIST=""
@@ -1294,6 +1298,8 @@ getPkgList() {
         PKG_LIST=$(dpkg -l | awk '{print $2"-"$3}' | sed 's/:amd64//g')
     elif [ "$distro" = "RHEL" -o "$distro" = "fedora" -o "$distro" = "mageia" ]; then
         PKG_LIST=$(rpm -qa)
+    elif [ "$distro" = "arch" -o "$distro" = "manjaro" ]; then
+        PKG_LIST=$(pacman -Qe | awk '{print $1"-"$2}')
     else
         # packages listing not available
         PKG_LIST=""


### PR DESCRIPTION
Rudimentary parsing for pacman package list.

Calling it "support" is a bit of a stretch. I intentionally didn't change the usage text to mention pacman.

Most of the hard-coded `pkg` checks already in LES make use of Debian / Ubuntu package naming convention. As such, they didn't match before this patch. For the most part, they still don't match after this patch.

### Output (before patch)

```
[user@manjaro-gnome-17-1-0 linux-exploit-suggester]$ ./linux-exploit-suggester.sh 

Available information:

Kernel version: 4.14.10
Architecture: x86_64
Distribution: manjaro
Distribution version: 
Additional checks (CONFIG_*, sysctl entries, custom Bash commands): performed
Package listing: N/A

Searching among:

70 kernel space exploits
0 user space exploits

Possible Exploits:

```

```
[user@manjaro-gnome-17-1-0 linux-exploit-suggester]$ ./linux-exploit-suggester.sh -p pkg

Available information:

Kernel version: N/A
Architecture: N/A
Distribution: N/A
Distribution version: N/A
Additional checks (CONFIG_*, sysctl entries, custom Bash commands): N/A
Package listing: unrecognized file provided

Searching among:

0 kernel space exploits
0 user space exploits

Possible Exploits:
```

### Output (after patch)

```
[user@manjaro-gnome-17-1-0 linux-exploit-suggester]$ ./linux-exploit-suggester.sh 

Available information:

Kernel version: 4.14.10
Architecture: x86_64
Distribution: manjaro
Distribution version: 
Additional checks (CONFIG_*, sysctl entries, custom Bash commands): performed
Package listing: from current OS

Searching among:

70 kernel space exploits
32 user space exploits

Possible Exploits:

[+] [CVE-2017-0358] ntfs-3g-modprobe

   Details: https://bugs.chromium.org/p/project-zero/issues/detail?id=1072
   Tags: ubuntu=16.04|16.10,debian=7|8
   Download URL: https://github.com/offensive-security/exploit-database-bin-sploits/raw/master/bin-sploits/41356.zip
   Comments: Distros use own versioning scheme. Manual verification needed. Linux headers must be installed. System must have at least two CPU cores.
```

```
[user@manjaro-gnome-17-1-0 linux-exploit-suggester]$ ./linux-exploit-suggester.sh -p pkg

Available information:

Kernel version: N/A
Architecture: N/A
Distribution: arch
Distribution version: N/A
Additional checks (CONFIG_*, sysctl entries, custom Bash commands): N/A
Package listing: pkg

Searching among:

0 kernel space exploits
32 user space exploits

Possible Exploits:

[+] [CVE-2014-5119] __gconv_translit_find

   Details: http://googleprojectzero.blogspot.com/2014/08/the-poisoned-nul-byte-2014-edition.html
   Tags: debian=6
   Download URL: https://github.com/offensive-security/exploit-database-bin-sploits/raw/master/bin-sploits/34421.tar.gz

[+] [CVE-2017-0358] ntfs-3g-modprobe

   Details: https://bugs.chromium.org/p/project-zero/issues/detail?id=1072
   Tags: ubuntu=16.04|16.10,debian=7|8
   Download URL: https://github.com/offensive-security/exploit-database-bin-sploits/raw/master/bin-sploits/41356.zip
   Comments: Distros use own versioning scheme. Manual verification needed. Linux headers must be installed. System must have at least two CPU cores.

[+] [CVE-2018-1000001] RationalLove

   Details: https://www.halfdog.net/Security/2017/LibcRealpathBufferUnderflow/
   Tags: debian=9{glibc:2.24-11+deb9u1},ubuntu=16.04.3{glibc:2.23-0ubuntu9}
   Download URL: https://www.halfdog.net/Security/2017/LibcRealpathBufferUnderflow/RationalLove.c
   Comments: kernel.unprivileged_userns_clone=1 required

[user@manjaro-gnome-17-1-0 linux-exploit-suggester]$ 
```

### Sample package list:

```
[user@manjaro-gnome-17-1-0 linux-exploit-suggester]$ cat pkg 
acpi 1.7-2
acpid 2.0.28-1
adwaita-icon-theme 3.26.1-1
alsa-firmware 1.0.29-1
alsa-utils 1.1.5-2
arc-maia-icon-theme 20161122-3
avahi 0.7-2
b43-fwcutter 019-1
baobab 3.26.1-1
bash 4.4.012-2.2
bijiben 3.26.2-2
brasero 3.12.2-2
btrfs-progs 4.14-2
bzip2 1.0.6-6
coreutils 8.28-1
cpupower 4.14-1
crda 3.18-1
cronie 1.5.1-1
cryptsetup 2.0.0-1
dconf-editor 3.26.2-1
device-mapper 2.02.177-1
dhclient 4.3.6-4
dhcpcd 6.11.5-1
diffutils 3.6-1
dmidecode 3.1-2
dmraid 1.0.0.rc16.3-10
dnsmasq 2.78-1
dosfstools 4.1-1
e2fsprogs 1.43.7-1
ecryptfs-utils 111-2
efibootmgr 15-1
empathy 3.25.90+33+g1453dc4e7-1
evince 3.26.0+14+g2a499547-1
evolution 3.26.3-1
exfat-utils 1.2.7-1
f2fs-tools 1.9.0-1
file 5.32-1
file-roller 3.26.2-1
filesystem 2017.06-4.5
findutils 4.6.0-2
firefox 57.0.3-1
gawk 4.2.0-2
gcc-libs 7.2.1-2
gdm 3.26.2.1-1
gedit 3.22.1+1+gd21912e3e-1
gettext 0.19.8.1-2
git 2.18.0-1
glibc 2.26-8
gnome-backgrounds 3.26.2-1
gnome-calculator 3.26.0-1
gnome-calendar 3.26.2+19+g954c48d7-1
gnome-characters 3.26.2-1
gnome-clocks 3.26.1-1
gnome-contacts 3.26+3+g643f622-1
gnome-control-center 3.26.2+14+g5ac6a0da6-1
gnome-desktop 1:3.26.2-2
gnome-disk-utility 3.26.2-1
gnome-font-viewer 3.26.0-1
gnome-getting-started-docs 3.26.2-1
gnome-keyring 1:3.27.2-1
gnome-maps 3.26.2-1
gnome-online-accounts 3.26.2-1
gnome-screenshot 3.26.0-1
gnome-session 3.26.1-2
gnome-settings-daemon 3.26.2-1
gnome-shell 3.26.2+9+ga3736d3a3-1
gnome-shell-extension-manjaro-update 3.3-1
gnome-shell-extensions 3.26.2-1
gnome-system-log 3.9.90+160+g4b07190-1
gnome-system-monitor 3.26.0+1+g97b9578d-1
gnome-terminal 3.26.2-1
gnome-themes-standard 3.22.3+13+ga993fdc0-1
gnome-todo 3.26.2-2
gnome-tweak-tool 3.26.4-1
gnome-user-docs 3.26.2.1-1
gnome-user-share 3.18.3+2+g7b451ae-1
gnome-wallpapers 20171025-1
gnome-weather 3.26.0-1
gparted 0.30.0-3
grep 3.1-1
grilo-plugins 0.3.5-1
grub 2.02.0-4
gst-libav 1.12.4-1
gst-plugins-bad 1.12.4-1
gst-plugins-base 1.12.4-1
gst-plugins-good 1.12.4-1
gst-plugins-ugly 1.12.4-1
gthumb 3.6.0-1
gtk3 3.22.26+47+g3a1a7135a2-3
gtksourceview-pkgbuild 3-2
gufw 17.10.0-1
gvfs 1.34.1+8+g091ac25d-1
gvfs-afc 1.34.1+8+g091ac25d-1
gvfs-google 1.34.1+8+g091ac25d-1
gvfs-mtp 1.34.1+8+g091ac25d-1
gvfs-smb 1.34.1+8+g091ac25d-1
gzip 1.8-2
haveged 1.9.1-4
hexchat 2.12.4-7
imagewriter 1.10.1420800585.134a9b3-4
inetutils 1.9.4-5
intel-ucode 20171117-1
inxi 2.3.53-1
iproute2 4.14.1-2
iptables 1.6.1-2
iputils 20161105.1f2bb12-2
ipw2100-fw 1.3-8
ipw2200-fw 3.1-6
jfsutils 1.1.15-4
jre8-openjdk 8.u144-1
jre8-openjdk-headless 8.u144-1
kvantum-manjaro 0.10.5-3
less 487-1
lib32-mesa-demos 8.3.0-3
libdvdcss 1.4.0-2
libreoffice-fresh 5.4.4-1
licenses 20171006-1
linux-firmware 20171206.fdee922-1
linux414 4.14.10-2
logrotate 3.13.0-1
lollypop 0.9.306-1
lrzip 0.631-1
lsb-release 1.4-12
lvm2 2.02.177-1
man-db 2.7.6.1-2
man-pages 4.14-1
manjaro-alsa 2012.11-1
manjaro-artwork 1.0.8-4
manjaro-aur-support 0.6-1
manjaro-browser-settings 20161221-1
manjaro-documentation-en 20171227-1
manjaro-firmware 20160419-1
manjaro-gdm-check 20171230-1
manjaro-gnome-maia-theme 20171118-1
manjaro-gnome-settings 20171230-1
manjaro-hello 0.5.11-1
manjaro-hotfixes 2015.12-3
manjaro-printer 20170501-1
manjaro-pulse 2012.11-1
manjaro-release 17.1.0-1
manjaro-settings-manager-notifier 0.5.4-8
manjaro-system 20180716-1
manjaro-wallpapers-17.0 1.0-2
mc 4.8.20-1
mdadm 4.0-1
memtest86+ 5.01-2
mesa-demos 8.3.0-4
mhwd 0.6.0-2
mhwd-db 0.6.0-1
mhwd-tui 0.4-1
mkinitcpio-openswap 0.1.0-2
mobile-broadband-provider-info 20170310-1
modemmanager 1.6.12-1
mousetweaks 3.12.0-2
ms-office-online 17.10.5-3
mutter 3.26.2+31+gbf91e2b4c-1
nano 2.9.1-1
nautilus 3.26.2-1
nautilus-admin 1.1.1-1
nautilus-empty-file 1.2-1
netctl 1.14-1
networkmanager 1.10.2-1
networkmanager-dispatcher-ntpd 1.0-6
networkmanager-openconnect 1.2.4-3
networkmanager-openvpn 1.8.1dev+10+ge4d8cda-2
networkmanager-pptp 1.2.4-3
networkmanager-vpnc 1.2.4-3
nfs-utils 2.3.1-1
nss-mdns 0.10-6
ntfs-3g 2017.3.23-1
ntp 4.2.8.p10-2
numlockx 1.2-3
open-vm-tools 6:10.2.0-1
openresolv 3.9.0-1
openssh 7.6p1-1
os-prober 1.76-1
p7zip 16.02-3
pacman 5.0.2-2
pamac 6.2.2-3
pciutils 3.5.6-1
pcmciautils 018-7
perl 5.26.1-1
polkit-gnome 0.105-3
powertop 2.9-1
procps-ng 3.3.12-1.1
psmisc 23.1-1
pulseaudio-bluetooth 11.1-1
pulseaudio-ctl 1.66-1
pulseaudio-zeroconf 11.1-1
reiserfsprogs 3.6.27-1
rsync 3.1.2-8
s-nail 14.9.6-1
seahorse 3.20.0+105+gb31e32fe-1
sed 4.4-1
shadow 4.5-4
simple-scan 3.26.2-1
steam-manjaro 1.0.0.54-9
sudo 1.8.21.p2-1
sushi 3.24.0-1
sysfsutils 2.1.0-9
systemd-sysvcompat 236.0-2
tar 1.30-1
telepathy-accounts-signon 1.0-1
terminus-font 4.46-1.1
texinfo 6.5-1
tlp 1.0-1.4
totem 3.26.0+1+g4e309671-1
tracker 2.0.2-1
transmission-gtk 2.92-7
ttf-bitstream-vera 1.10-11
ttf-dejavu 2.37-1
ttf-droid 20121017-5
ttf-inconsolata 20151221.480630d-2
ttf-indic-otf 0.2-8
ttf-liberation 2.00.1-7
uget 2.0.10-1
unace 2.5-9
unrar 1:5.5.8-1
usb_modeswitch 2.5.1-1.2
usbutils 009-1
util-linux 2.31.1-1
vi 1:070224-2
vino 3.22.0+7+g74dd40f-1
wget 1.19.2-1
which 2.21-2
wpa_supplicant 1:2.6-11
xdg-su 1.2.3-1
xdg-user-dirs 0.16-1
xdg-user-dirs-gtk 0.10+9+g5b7efc6-1
xdg-utils 1.1.2-1
xf86-input-elographics 1.4.1-7
xf86-input-evdev 2.10.5-1
xf86-input-keyboard 1.9.0-2
xf86-input-libinput 0.26.0-1
xf86-input-mouse 1.9.2-3
xf86-input-vmmouse 13.1.0-3
xf86-input-void 1.4.1-3
xf86-video-vmware 13.2.1-3
xfsprogs 4.13.1-1
xorg-server 1.19.6-2
xorg-twm 1.0.9-1
xorg-xinit 1.3.4-4
yelp 3.26.0-1
zd1211-firmware 1.5-1
zsh 5.4.2-1
[user@manjaro-gnome-17-1-0 linux-exploit-suggester]$ 
```
