### PR TITLE
Add vpnc_privesc.py (CVE-2018-10900)

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -1069,6 +1069,18 @@ author: halfdog
 EOF
 )
 
+EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+Name: ${txtgrn}[CVE-2018-10900]${txtrst} vpnc_privesc.py
+Reqs: pkg=networkmanager-vpnc|network-manager-vpnc,ver<1.2.6
+Tags: ubuntu=16.04,debian=9,manjaro=17
+analysis-url: https://pulsesecurity.co.nz/advisories/NM-VPNC-Privesc
+src-url: https://bugzilla.novell.com/attachment.cgi?id=779110
+exploit-db: 45313
+author: Denis Andzakovic
+Comments: Distros use own versioning scheme. Manual verification needed.
+EOF
+)
+
 ###########################################################
 ## security related HW/kernel features
 ###########################################################


### PR DESCRIPTION
Add vpnc_privesc.py (CVE-2018-10900). Reliable userland exploit.

```
[user@manjaro-gnome-17-1-0 linux-exploit-suggester]$ ./linux-exploit-suggester.sh 

Available information:

Kernel version: 4.14.10
Architecture: x86_64
Distribution: manjaro
Distribution version: 
Additional checks (CONFIG_*, sysctl entries, custom Bash commands): performed
Package listing: from current OS

Searching among:

70 kernel space exploits
33 user space exploits

Possible Exploits:

[+] [CVE-2017-0358] ntfs-3g-modprobe

   Details: https://bugs.chromium.org/p/project-zero/issues/detail?id=1072
   Tags: ubuntu=16.04|16.10,debian=7|8
   Download URL: https://github.com/offensive-security/exploit-database-bin-sploits/raw/master/bin-sploits/41356.zip
   Comments: Distros use own versioning scheme. Manual verification needed. Linux headers must be installed. System must have at least two CPU cores.

[+] [CVE-2018-10900] vpnc_privesc.py

   Details: https://pulsesecurity.co.nz/advisories/NM-VPNC-Privesc
   Tags: ubuntu=16.04,debian=9,manjaro=17
   Download URL: https://bugzilla.novell.com/attachment.cgi?id=779110
   Comments: Distros use own versioning scheme. Manual verification needed.

[user@manjaro-gnome-17-1-0 linux-exploit-suggester]$ 
```