### PR TITLE
Add bin-url for msf cross-compiled exploits

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -656,6 +656,7 @@ Reqs: pkg=linux-kernel,ver>=4.4.0,ver<4.9,CONFIG_USER_NS=y,sysctl:kernel.unprivi
 Tags: ubuntu=(14.04|16.04){kernel:4.4.0-(21|22|24|28|31|34|36|38|42|43|45|47|51)-generic}
 analysis-url: http://www.openwall.com/lists/oss-security/2016/12/06/1
 Comments: CAP_NET_RAW capability is needed OR CONFIG_USER_NS=y needs to be enabled
+bin-url: https://raw.githubusercontent.com/rapid7/metasploit-framework/master/data/exploits/CVE-2016-8655/chocobo_root
 exploit-db: 40871
 author: rebel
 EOF
@@ -692,6 +693,7 @@ analysis-url: https://googleprojectzero.blogspot.com/2017/05/exploiting-linux-ke
 src-url: https://raw.githubusercontent.com/xairy/kernel-exploits/master/CVE-2017-7308/poc.c
 ext-url: https://raw.githubusercontent.com/bcoles/kernel-exploits/cve-2017-7308/CVE-2017-7308/poc.c
 Comments: CAP_NET_RAW cap or CONFIG_USER_NS=y needed. Modified version at 'ext-url' adds support for additional kernels
+bin-url: https://raw.githubusercontent.com/rapid7/metasploit-framework/master/data/exploits/cve-2017-7308/exploit
 exploit-db: 41994
 author: Andrey 'xairy' Konovalov (orginal exploit author); Brendan Coles (author of exploit update at 'ext-url')
 EOF
@@ -703,6 +705,7 @@ Reqs: pkg=linux-kernel,ver>=4.4,ver<=4.14.8,CONFIG_BPF_SYSCALL=y,sysctl:kernel.u
 Tags: debian=9,fedora=25|26|27,ubuntu=14.04|16.04|17.04
 analysis-url: https://ricklarabee.blogspot.com/2018/07/ebpf-and-analysis-of-get-rekt-linux.html
 Comments: CONFIG_BPF_SYSCALL needs to be set && kernel.unprivileged_bpf_disabled != 1
+bin-url: https://raw.githubusercontent.com/rapid7/metasploit-framework/master/data/exploits/cve-2017-16995/exploit.out
 exploit-db: 45010
 author: Rick Larabee
 EOF
@@ -716,6 +719,7 @@ analysis-url: http://www.openwall.com/lists/oss-security/2017/08/13/1
 src-url: https://raw.githubusercontent.com/xairy/kernel-exploits/master/CVE-2017-1000112/poc.c
 ext-url: https://raw.githubusercontent.com/bcoles/kernel-exploits/cve-2017-1000112/CVE-2017-1000112/poc.c
 Comments: CAP_NET_ADMIN cap or CONFIG_USER_NS=y needed. SMEP/KASLR bypass included. Modified version at 'ext-url' adds support for additional distros/kernels
+bin-url: https://raw.githubusercontent.com/rapid7/metasploit-framework/master/data/exploits/cve-2017-1000112/exploit.out
 exploit-db:
 author: Andrey 'xairy' Konovalov (orginal exploit author); Brendan Coles (author of exploit update at 'ext-url')
 EOF
@@ -1064,6 +1068,7 @@ Tags: debian=9{glibc:2.24-11+deb9u1},ubuntu=16.04.3{glibc:2.23-0ubuntu9}
 analysis-url: https://www.halfdog.net/Security/2017/LibcRealpathBufferUnderflow/
 src-url: https://www.halfdog.net/Security/2017/LibcRealpathBufferUnderflow/RationalLove.c
 Comments: kernel.unprivileged_userns_clone=1 required
+bin-url: https://raw.githubusercontent.com/rapid7/metasploit-framework/master/data/exploits/cve-2018-1000001/RationalLove
 exploit-db: 43775
 author: halfdog
 EOF


### PR DESCRIPTION
Adds some URLs for cross-compiled exploits.

In most instances, the exploit has been modified, albeit slightly, from the original exploit code.
