### PR TITLE
Add subuid_shell (CVE-2018-18955)

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -739,7 +739,7 @@ EOF
 
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2018-18955]${txtrst} subuid_shell
-Reqs: pkg=linux-kernel,ver>=4.15,ver<=4.19.2,CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1
+Reqs: pkg=linux-kernel,ver>=4.15,ver<=4.19.2,CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1,cmd:[ -u /usr/bin/newuidmap ],cmd:[ -u /usr/bin/newgidmap ]
 Tags: ubuntu=18
 analysis-url: https://bugs.chromium.org/p/project-zero/issues/detail?id=1712
 exploit-db: 45886

--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -742,6 +742,7 @@ Name: ${txtgrn}[CVE-2018-18955]${txtrst} subuid_shell
 Reqs: pkg=linux-kernel,ver>=4.15,ver<=4.19.2,CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1,cmd:[ -u /usr/bin/newuidmap ],cmd:[ -u /usr/bin/newgidmap ]
 Tags: ubuntu=18
 analysis-url: https://bugs.chromium.org/p/project-zero/issues/detail?id=1712
+src-url: https://github.com/offensive-security/exploitdb-bin-sploits/raw/master/bin-sploits/45886.zip
 exploit-db: 45886
 author: Jann Horn
 Comments: CONFIG_USER_NS needs to be enabled

--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -737,6 +737,17 @@ Comments:
 EOF
 )
 
+EXPLOITS[((n++))]=$(cat <<EOF
+Name: ${txtgrn}[CVE-2018-18955]${txtrst} subuid_shell
+Reqs: pkg=linux-kernel,ver>=4.15,ver<=4.19.2,CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1
+Tags: ubuntu=18
+analysis-url: https://bugs.chromium.org/p/project-zero/issues/detail?id=1712
+exploit-db: 45886
+author: Jann Horn
+Comments: CONFIG_USER_NS needs to be enabled
+EOF
+)
+
 ############ USERSPACE EXPLOITS ###########################
 n=0
 


### PR DESCRIPTION
Linux kernel 4.15.x to 4.18.x prior to 4.18.19 and 4.19.x before 4.19.2 privileged arbitrary file read/write by abusing broken uid/gid mapping in nested namespaces.
