### PR TITLE
Add feature check: Linux Kernel Runtime Guard (LKRG)

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -1204,6 +1204,13 @@ EOF
 )
 
 FEATURES[((n++))]=$(cat <<EOF
+feature: Linux Kernel Runtime Guard (LKRG) kernel module
+available: cmd:test -d /proc/sys/lkrg
+analysis-url: https://github.com/mzet-/les-res/blob/master/features/lkrg.md
+EOF
+)
+
+FEATURES[((n++))]=$(cat <<EOF
 section: Attack Surface:
 EOF
 )


### PR DESCRIPTION
Add check for Linux Kernel Runtime Guard (LKRG) kernel module.

I opted to use the `/proc/sys/lkrg` path for detection, as this works even though the sysctl values aren't readable by low privileged users, and will work regardless of whether LKRG was hidden with `lkrg.hide=1` sysctl parameter.

If LKRG kernel module is installed ("available") then it is also "enabled". There's no audit/monitor mode.

![LKRG](https://user-images.githubusercontent.com/434827/49686636-58754700-fb4b-11e8-8d65-7c075c6d0b5e.png)
