### PR TITLE
Add support for equery

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -1348,6 +1348,8 @@ getPkgList() {
         PKG_LIST=$(rpm -qa)
     elif [ "$distro" = "arch" -o "$distro" = "manjaro" ]; then
         PKG_LIST=$(pacman -Q | awk '{print $1"-"$2}')
+    elif [ -x /usr/bin/equery ]; then
+        PKG_LIST=$(/usr/bin/equery --quiet list '*' -F '$name:$version' | cut -d/ -f2- | awk '{print $1":"$2}')
     else
         # packages listing not available
         PKG_LIST=""


### PR DESCRIPTION
Rudimentary parsing for equery package list.

Calling it "support" is a bit of a stretch. I intentionally didn't change the usage text to mention `equery`. I didn't bother implementing support for `-p`.

Most of the hard-coded `pkg` checks already in LES make use of Debian / Ubuntu package naming convention. As such, they didn't match before this patch. For the most part, they still don't match after this patch.

This is the same issue as the package list parsing for pacman (#30). Not a big deal: we can add package names for debian/pacman/equery to each exploit if we want.

The good news is that `glibc` does match, and given that this is the most exploited userland package, this is a quick win.
