### PR TITLE
Add s-nail-privsep

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -1003,6 +1003,18 @@ EOF
 )
 
 EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+Name: ${txtgrn}[CVE-2017-5899]${txtrst} s-nail-privsep
+Reqs: pkg=s-nail,ver<14.8.16
+Tags: ubuntu=16.04,manjaro=16.10
+analysis-url: https://www.openwall.com/lists/oss-security/2017/01/27/7
+src-url: https://www.openwall.com/lists/oss-security/2017/01/27/7/1
+ext-url: https://raw.githubusercontent.com/bcoles/local-exploits/master/CVE-2017-5899/exploit.sh
+author: wapiflapi (orginal exploit author); Brendan Coles (author of exploit update at 'ext-url')
+Comments: Distros use own versioning scheme. Manual verification needed.
+EOF
+)
+
+EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2017-1000367]${txtrst} Sudoer-to-root
 Reqs: pkg=sudo,ver<=1.8.20,cmd:[ -f /usr/sbin/getenforce ]
 Tags: RHEL=7{sudo:1.8.6p7}


### PR DESCRIPTION
```
[+] [CVE-2017-5899] s-nail-privsep

   Details: https://www.openwall.com/lists/oss-security/2017/01/27/7
   Tags: ubuntu=16.04,manjaro=16.10
   Download URL: https://www.openwall.com/lists/oss-security/2017/01/27/7/1
   ext-url: https://raw.githubusercontent.com/bcoles/local-exploits/master/CVE-2017-5899/exploit.sh
   Comments: Distros use own versioning scheme. Manual verification needed.
```
