### PR TITLE
Fix typo

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -1003,7 +1003,7 @@ EOF
 )
 
 EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
-Name: ${txtgrn}[CVE-2017-5899]${txtrst} s-nail-privsep
+Name: ${txtgrn}[CVE-2017-5899]${txtrst} s-nail-privget
 Reqs: pkg=s-nail,ver<14.8.16
 Tags: ubuntu=16.04,manjaro=16.10
 analysis-url: https://www.openwall.com/lists/oss-security/2017/01/27/7


### PR DESCRIPTION
Fix typo in exploit name: `s-nail-privsep` -> `s-nail-privget`

The exploit is named `s-nail-privget`, playing off the name of the vulnerable executable `s-nail-privsep` (on Ubuntu systems).
