### PR TITLE
Add blueman set_dhcp_handler d-bus privesc (CVE-2015-8612)

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -995,6 +995,18 @@ EOF
 )
 
 EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+Name: ${txtgrn}[CVE-2015-8612]${txtrst} blueman set_dhcp_handler d-bus privesc
+Reqs: pkg=blueman,ver<2.0.3
+Tags: debian=8{blueman:1.23}
+Rank: 1
+analysis-url: https://twitter.com/thegrugq/status/677809527882813440
+exploit-db: 46186
+author: Sebastian Krahmer
+Comments: Distros use own versioning scheme. Manual verification needed.
+EOF
+)
+
+EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-1240]${txtrst} tomcat-rootprivesc-deb.sh
 Reqs: pkg=tomcat
 Tags: debian=8,ubuntu=16.04


### PR DESCRIPTION
Add blueman set_dhcp_handler d-bus privesc (CVE-2015-8612)

There's no "exploit" for this bug. The PoC [fits in a tweet](https://twitter.com/thegrugq/status/677809527882813440) (`analysis-url`).

Unfortunately, I haven't found any way to link directly to raw tweet content (without an API key).

The `exploit-db: 46186` ID is for the [Metasploit module](https://github.com/rapid7/metasploit-framework/blob/master/documentation/modules/exploit/linux/local/blueman_set_dhcp_handler_dbus_priv_esc.md).

The PoC is small and "just works". It's hard to justify writing a separate exploit for it.
