### PR TITLE
Add Kernel Page Table Isolation (PTI) detection

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -1450,6 +1450,14 @@ EOF
 )
 
 FEATURES[((n++))]=$(cat <<EOF
+feature: Kernel Page Table Isolation (PTI) support
+available: ver>=4.15
+enabled: cmd:grep -Eqi '\spti' /proc/cpuinfo
+analysis-url: https://github.com/mzet-/les-res/blob/master/features/pti.md
+EOF
+)
+
+FEATURES[((n++))]=$(cat <<EOF
 section: 3rd party kernel protection mechanisms:
 EOF
 )

--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -1258,6 +1258,14 @@ EOF
 )
 
 FEATURES[((n++))]=$(cat <<EOF
+feature: Kernel Page Table Isolation (PTI) support
+available: ver>=4.15
+enabled: cmd:grep -Eqi '\spti' /proc/cpuinfo
+analysis-url: https://github.com/mzet-/les-res/blob/master/features/pti.md
+EOF
+)
+
+FEATURES[((n++))]=$(cat <<EOF
 feature: GCC stack protector support
 available: CONFIG_HAVE_STACKPROTECTOR=y
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/stackprotector-regular.md
@@ -1446,14 +1454,6 @@ feature: Supervisor Mode Access Prevention (SMAP) support
 available: ver>=3.7
 enabled: cmd:grep -qi smap /proc/cpuinfo
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/smap.md
-EOF
-)
-
-FEATURES[((n++))]=$(cat <<EOF
-feature: Kernel Page Table Isolation (PTI) support
-available: ver>=4.15
-enabled: cmd:grep -Eqi '\spti' /proc/cpuinfo
-analysis-url: https://github.com/mzet-/les-res/blob/master/features/pti.md
 EOF
 )
 


### PR DESCRIPTION
Add Kernel Page Table Isolation (PTI) detection.

```
Hardware-based protection features:

 [ Enabled  ] Supervisor Mode Execution Protection (SMEP) support 
              https://github.com/mzet-/les-res/blob/master/features/smep.md

 [ Enabled  ] Supervisor Mode Access Prevention (SMAP) support 
              https://github.com/mzet-/les-res/blob/master/features/smap.md

 [ Enabled  ] Kernel Page Table Isolation (PTI) support 
              https://github.com/mzet-/les-res/blob/master/features/pti.md
```

I've added PTI to the `Hardware-based` section, however this isn't entirely accurate. PTI is implemented in software (kernel), not hardware, and does not rely on hardware functionality (at least as far as x86/x86_64 is concerned - not sure about other archs).

I placed it in the hardware section for a couple of reasons. Firstly, the information is available from `/proc/cpuinfo`. This is a more reliable check than `CONFIG_PAGE_TABLE_ISOLATION`, as PTI may have been disabled in the kernel boot config with `pti=off`. Secondly, from an exploitation perspective, [PTI effectively emulates SMEP](https://outflux.net/blog/archives/2018/02/05/security-things-in-linux-v4-15/) for CPUs which are not SMEP-capable, so grouping it with SMEP/SMAP kind of makes sense.

As an aside, none of the kernel exploits in LES target 4.15+ kernels, so there's no need to add PTI checks to any of the exploit checks, yet.

```
available: ver>=4.15
```

May not be entirely accurate. PTI was born out of KAISER, and implemented as Meltdown mitigation. The exact kernel version is unclear (at least, from a quick search) due to the secrecy at the time. It was possible first introduced in a 4.15 RC, and was officially released in 4.15.

```
enabled: cmd:grep -Eqi '\spti' /proc/cpuinfo
```

The `-E` flag and match on whitespace `\s` is required, as `pti` will also match on `fpu_exception`. Matching `\spti\s` is also out of the question, unless you also want to deal with matching EOL, as `pti` could potentially be the last core flag listed.

```
analysis-url: https://github.com/mzet-/les-res/blob/master/features/pti.md
```

~Doesn't exist yet.~ https://github.com/mzet-/les-res/pull/3
