### PR TITLE
Clean up package list parsing

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -1602,25 +1602,25 @@ getPkgList() {
     if [ "$opt_pkglist_file" = "true" -a -e "$pkglist_file" ]; then
 
         # ubuntu/debian package listing file
-        if [ $(cat "$pkglist_file" | head -1 | grep 'Desired=Unknown/Install/Remove/Purge/Hold') ]; then 
+        if [ $(head -1 "$pkglist_file" | grep 'Desired=Unknown/Install/Remove/Purge/Hold') ]; then
             PKG_LIST=$(cat "$pkglist_file" | awk '{print $2"-"$3}' | sed 's/:amd64//g')
 
             OS="debian"
-            [ "$(cat "$pkglist_file" | grep "ubuntu")" ] && OS="ubuntu"
+            [ "$(grep ubuntu "$pkglist_file")" ] && OS="ubuntu"
         # redhat package listing file
-        elif [ $(cat "$pkglist_file" | head -1 | grep -E '\.el[1-9]+\.') ]; then
+        elif [ "$(grep -E '\.el[1-9]+[\._]' "$pkglist_file" | head -1)" ]; then
             PKG_LIST=$(cat "$pkglist_file")
             OS="RHEL"
         # fedora package listing file
-        elif [ $(cat "$pkglist_file" | head -1 | grep -E '\.fc[1-9]+') ]; then
+        elif [ "$(grep -E '\.fc[1-9]+'i "$pkglist_file" | head -1)" ]; then
             PKG_LIST=$(cat "$pkglist_file")
             OS="fedora"
         # mageia package listing file
-        elif [ $(cat "$pkglist_file" | head -1 | grep -E '\.mga[1-9]+') ]; then
+        elif [ "$(grep -E '\.mga[1-9]+' "$pkglist_file" | head -1)" ]; then
             PKG_LIST=$(cat "$pkglist_file")
             OS="mageia"
         # pacman package listing file
-        elif [ "$(head -1 $pkglist_file | grep -E '\ [0-9]+\.')" ]; then
+        elif [ "$(grep -E '\ [0-9]+\.' "$pkglist_file" | head -1)" ]; then
             PKG_LIST=$(cat "$pkglist_file" | awk '{print $1"-"$2}')
             OS="arch"
         # file not recognized - skipping


### PR DESCRIPTION
This PR adds `_` to the package pattern match for RHEL: `'\.el[1-9]+[\._]'`.

This PR also reworks the package list parsing for each OS, such that `cat` is no longer required.

`head` is still used, but moved to the end of the expression, so that `elif` doesn't complain.

The use of `head -1` could probably be replaced with `[ -z "$str" ]` expression; however, I didn't implement this as I couldn't be bothered testing on a bunch of systems and versions of Bash.


### Issue

LES uses regex pattern matching on the first line (`head -1 ...`) of the package list to determine to the package list format and OS.

The match is insufficient for RHEL systems, as there's no guarantee that the first line will contain the `el[0-9]` pattern.

For example, the following output is from `rpm -qa` on a RHEL5.5 box:

```
# head -n 20 pkg 
tzdata-2010e-1.el5
gnome-audio-2.0.0-3.1.1
redhat-release-notes-5Server-31
libstdc++-4.1.2-48.el5
info-4.8-14.el5
freetype-2.2.1-21.el5_3
db4-4.3.29-10.el5
zlib-1.2.3-3
freetype-2.2.1-21.el5_3
libjpeg-6b-37
ncurses-5.5-24.20060715
keyutils-libs-1.2-1.el5
time-1.7-27.2.2
pax-3.4-2.el5
dmidecode-2.10-3.el5
libjpeg-6b-37
libXau-1.0.1-3.1
groff-1.18.1.1-11.1
bc-1.06-21
ethtool-6-4.el5
```

Additionally, when `el[0-9]` is present in the package name, there's no guarantee that the package name format will always match the `\.el[0-9]+\.` pattern. For example, on RHEL 5, the pattern `el5_` is often used, rather than a `el5.`.

```
# cat pkg | head -50 | grep -E '\.el[1-9]+\.'
# cat pkg | head -50 | grep -E '\.el[1-9]+[\._]'
freetype-2.2.1-21.el5_3
freetype-2.2.1-21.el5_3
cyrus-sasl-plain-2.1.22-5.el5_4.3
speex-1.0.5-4.el5_1.1
neon-0.25.5-10.el5_4.1
# cat pkg |  grep -E '\.el[1-9]+\.'
automake16-1.6.3-8.el5.1
tmpwatch-2.9.7-1.1.el5.2
automake15-1.5-16.el5.2
automake17-1.7.9-7.el5.2
m4-1.4.5-3.el5.1
m2crypto-0.16-6.el5.6
usermode-1.88-3.el5.2
usermode-gtk-1.88-3.el5.2
hwdata-0.213.18-1.el5.1
automake14-1.4p6-13.el5.1
stunnel-4.15-2.el5.1
mlocate-0.15-1.el5.2
```

```
# cat pkg |  grep -E '\.el[1-9]+[\._]' | wc -l
98
# cat pkg |  grep -E '\.el[1-9]+\.' | wc -l
12
# cat pkg |  grep -E '\.el[1-9]+_' | wc -l
86
```