### PR TITLE
Add SystemTap exploit (CVE-2010-4170)

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -872,6 +872,16 @@ EOF
 )
 
 EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+Name: ${txtgrn}[CVE-2010-4170]${txtrst} SystemTap
+Reqs: pkg=systemtap,ver<=1.3
+Tags: RHEL=5{systemtap:1.1-3.el5},fedora=13{systemtap:1.2-1.fc13}
+Rank: 1
+author: Tavis Ormandy
+exploit-db: 15620
+EOF
+)
+
+EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2011-1485]${txtrst} pkexec
 Reqs: pkg=polkit,ver=0.96
 Tags: RHEL=6,ubuntu=10.04|10.10


### PR DESCRIPTION
Add [SystemTap trivial root LPE](https://access.redhat.com/security/cve/cve-2010-4170) ([CVE-2010-4170](https://nvd.nist.gov/vuln/detail/CVE-2010-4170
)).

Installed by default on Fedora and RHEL.

RHEL 4,5,6 and Fedora 12,13,14 exploitable.

It's worth noting that LES won't run on an exploitable RHEL system, as the version of Bash is too old (<4). However, it's still a useful check for package lists.

![RHEL5.5](https://user-images.githubusercontent.com/434827/56270193-e9cb7a00-6138-11e9-935d-e2f25e329884.png)


![Fedora 13](https://user-images.githubusercontent.com/434827/56270208-f354e200-6138-11e9-8395-d63e953848fc.png)
