### PR TITLE
Add abrt/sosreport-rhel7 exploit

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -987,6 +987,18 @@ EOF
 )
 
 EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+Name: ${txtgrn}[CVE-2015-5287]${txtrst} abrt/sosreport-rhel7
+Reqs: pkg=abrt,cmd:grep -qi abrt /proc/sys/kernel/core_pattern
+Tags: RHEL=7{abrt:2.1.11-12.el7}
+Rank: 1
+analysis-url: https://www.openwall.com/lists/oss-security/2015/12/01/1
+src-url: https://www.openwall.com/lists/oss-security/2015/12/01/1/1
+exploit-db: 38832
+author: rebel
+EOF
+)
+
+EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-6565]${txtrst} not_an_sshnuke
 Reqs: pkg=openssh-server,ver>=6.8,ver<=6.9
 Tags:


### PR DESCRIPTION
Add [abrt/sosreport-rhel7 exploit](https://www.openwall.com/lists/oss-security/2015/12/01/1).

```
[user@localhost Desktop]$ python rhel-sosreport.py 
crashing pid 20538
waiting for dump directory
dump directory:  /var/tmp/abrt/ccpp-2019-04-18-09:38:48-20538
waiting for sosreport directory
sosreport:  sosreport-localhost.localdomain-20190418093857
waiting for tmpfiles
tmpfiles:  ['tmpxeUbFy', 'tmpLUBFqG']
moving directory
moving tmpfiles
tmpxeUbFy -> tmpxeUbFy.old
tmpLUBFqG -> tmpLUBFqG.old
waiting for sosreport to finish (can take several minutes)..................................................done
success
bash-4.2# id
uid=0(root) gid=1000(user) groups=0(root),1000(user) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
bash-4.2# rpm -qa | grep abrt
gnome-abrt-0.3.4-6.el7.x86_64
abrt-addon-pstoreoops-2.1.11-12.el7.x86_64
abrt-addon-ccpp-2.1.11-12.el7.x86_64
abrt-libs-2.1.11-12.el7.x86_64
abrt-2.1.11-12.el7.x86_64
abrt-addon-python-2.1.11-12.el7.x86_64
abrt-tui-2.1.11-12.el7.x86_64
abrt-desktop-2.1.11-12.el7.x86_64
abrt-python-2.1.11-12.el7.x86_64
abrt-addon-vmcore-2.1.11-12.el7.x86_64
abrt-dbus-2.1.11-12.el7.x86_64
abrt-gui-libs-2.1.11-12.el7.x86_64
abrt-gui-2.1.11-12.el7.x86_64
abrt-addon-xorg-2.1.11-12.el7.x86_64
abrt-console-notification-2.1.11-12.el7.x86_64
abrt-addon-kerneloops-2.1.11-12.el7.x86_64
abrt-cli-2.1.11-12.el7.x86_64
bash-4.2# cat /etc/redhat-release 
Red Hat Enterprise Linux Server release 7.0 (Maipo)
bash-4.2# 
```