### PR TITLE
Add ntfs-3g version check: pkg=ntfs-3g,ver<2017.4

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -1131,7 +1131,7 @@ EOF
 
 EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2017-0358]${txtrst} ntfs-3g-modprobe
-Reqs: pkg=ntfs-3g
+Reqs: pkg=ntfs-3g,ver<2017.4
 Tags: ubuntu=16.04{ntfs-3g:2015.3.14AR.1-1build1},debian=7.0{ntfs-3g:2012.1.15AR.5-2.1+deb7u2},debian=8.0{ntfs-3g:2014.2.15AR.2-1+deb8u2}
 Rank: 1
 analysis-url: https://bugs.chromium.org/p/project-zero/issues/detail?id=1072


### PR DESCRIPTION
Add a rudimentary version check for the `ntfs-3g` package for the `ntfs-3g-modprobe` exploit.

This exploit frequently shows up on modern systems due to lack of a package version check.

The bug was disclosed 2+ years ago, around January/February 2017. The versioning scheme makes use of `year.month` format, and was patched in ~`2017.3`.

The patch was also backported to earlier versions. For example:

[Ubuntu advisory](https://people.canonical.com/~ubuntu-security/cve/2017/CVE-2017-0358.html) :

![Ubuntu advisory](https://user-images.githubusercontent.com/434827/57564052-3da04a80-73e9-11e9-8193-195fd03fb768.png)

[Debian advisory](https://security-tracker.debian.org/tracker/CVE-2017-0358) :

![Debian advisory](https://user-images.githubusercontent.com/434827/57564060-5dd00980-73e9-11e9-9570-3b954441f867.png)

Checking for `<2017.4` seemed like the easiest and best way to eliminate false positives without causing false negatives. All package versions from `2017.4` onward *should* be patched.

Another option would be to check if the `ntfs-3g` binary is setuid `root`. For example, Ubuntu 14 was reportedly not vulnerable as the executable was not setuid. I opted not to check this, as the path may or may not be `/bin/ntfs-3g`, resulting in false negatives.

Another option would be to check for the `linux-headers` package. While this package is technically required for the exploit, presumably the exploit could be cross-compiled on another system. I opted not to include this check as it may introduce false negatives.
