### PR TITLE
Add udev version check pkg=udev,ver<141

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -843,7 +843,7 @@ EOF
 
 EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2009-1185]${txtrst} udev
-Reqs: pkg=udev,cmd:[[ -f /etc/udev/rules.d/95-udev-late.rules || -f /lib/udev/rules.d/95-udev-late.rules ]]
+Reqs: pkg=udev,ver<141,cmd:[[ -f /etc/udev/rules.d/95-udev-late.rules || -f /lib/udev/rules.d/95-udev-late.rules ]]
 Tags: ubuntu=8.10|9.04
 Rank: 1
 exploit-db: 8572
@@ -853,7 +853,7 @@ EOF
 
 EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2009-1185]${txtrst} udev 2
-Reqs: pkg=udev
+Reqs: pkg=udev,ver<141
 Tags:
 Rank: 1
 exploit-db: 8478


### PR DESCRIPTION
Add a rudimentary version check for the `udev` package for the `udev` and `udev 2` exploits.

This exploit frequently shows up on modern systems due to lack of a package version check. The bug was disclosed 10 years ago.

I checked a couple of modern Ubuntu systems (Ubuntu 19, Mint 19) and ancient Fedora 7. All made use of a similar versioning scheme, where the version has the dot separators removed. ie, version `1.4.1` == `141`.

As such, a simple version check against `<141` should be sufficient in most instances. If for some reason the target system does use dotted notation for the package version, it will still appear in the results, as dotted notation will always be `< 141` (at least, for the next ~140 major releases of `udev`, by which time I expect this won't be an issue).
