### PR TITLE
Add nginx version check: pkg=nginx|nginx-full,ver<1.10.3

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -1048,14 +1048,14 @@ EOF
 
 EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-1247]${txtrst} nginxed-root.sh
-Reqs: pkg=nginx|nginx-full
+Reqs: pkg=nginx|nginx-full,ver<1.10.3
 Tags: debian=8,ubuntu=14.04|16.04|16.10
 Rank: 1
 analysis-url: https://legalhackers.com/advisories/Nginx-Exploit-Deb-Root-PrivEsc-CVE-2016-1247.html
 src-url: https://legalhackers.com/exploits/CVE-2016-1247/nginxed-root.sh
 exploit-db: 40768
 author: Dawid Golunski
-Comments: Rooting depends on cron.daily (up to 24h of delay). Affected: deb8: <1.6.2; 14.04: <1.4.6; 16.04: 1.10.0
+Comments: Rooting depends on cron.daily (up to 24h of delay). Affected: deb8: <1.6.2; 14.04: <1.4.6; 16.04: 1.10.0; gentoo: <1.10.2-r3
 EOF
 )
 


### PR DESCRIPTION
Add a rudimentary version check for the `nginx` package for the `nginxed-root.sh` exploit.

This exploit frequently shows up on modern systems, with any version of nginx installed, due to lack of a package version check.

The bug was disclosed ~3 years ago. Checking for `<1.10.3` seemed like the easiest and best way to eliminate false positives without causing false negatives. All versions from `1.10.3` onward *should* be patched.
