### PR TITLE
Add Serv-U FTP Server exploit (CVE-2019-12181)

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -1286,6 +1286,20 @@ Comments: Distros use own versioning scheme. Manual verification needed.
 EOF
 )
 
+EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+Name: ${txtgrn}[CVE-2019-12181]${txtrst} Serv-U FTP Server
+Reqs: cmd:[ -u /usr/local/Serv-U/Serv-U ]
+Tags: debian=9
+Rank: 1
+analysis-url: https://blog.vastart.dev/2019/06/cve-2019-12181-serv-u-exploit-writeup.html
+exploit-db: 47009
+src-url: https://raw.githubusercontent.com/guywhataguy/CVE-2019-12181/master/servu-pe-cve-2019-12181.c
+ext-url: https://raw.githubusercontent.com/bcoles/local-exploits/master/CVE-2019-12181/SUroot
+author: Guy Levin (orginal exploit author); Brendan Coles (author of exploit update at 'ext-url')
+Comments: Modified version at 'ext-url' uses bash exec technique, rather than compiling with gcc.
+EOF
+)
+
 ###########################################################
 ## security related HW/kernel features
 ###########################################################


### PR DESCRIPTION
Add Serv-U FTP Server exploit (CVE-2019-12181).

Checking for `cmd:[ -u /usr/local/Serv-U/Serv-U ]` is not ideal, as the executable is setuid root for both the patched and unpatched versions.

Version detection isn't simple either, as the software isn't installed using a package manager. The version could be extracted from `/usr/local/Serv-U/Serv-U-StartupLog.txt` if the file exists; however, that is also not reliable, as attempts to execute the `Serv-U` binary by non-root users result in the log file being overwritten, thus removing the version string.
