### PR TITLE
Changes to fix warnings in ShellCheck

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -16,7 +16,7 @@ VERSION=v1.0
 txtred="\e[91;1m"
 txtgrn="\e[1;32m"
 txtgray="\e[0;37m"
-txtblu="\e[0;36m"
+#txtblu="\e[0;36m"
 txtrst="\e[0m"
 bldwht='\e[1;37m'
 wht='\e[0;36m'
@@ -226,7 +226,7 @@ EOF
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2009-2692,CVE-2009-1895]${txtrst} sock_sendpage2
 Reqs: pkg=linux-kernel,ver>=2.6.0,ver<=2.6.30
-Tags: 
+Tags:
 Rank: 1
 src-url: https://github.com/offensive-security/exploit-database-bin-sploits/raw/master/bin-sploits/9436.tgz
 exploit-db: 9436
@@ -237,7 +237,7 @@ EOF
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2009-2692,CVE-2009-1895]${txtrst} sock_sendpage3
 Reqs: pkg=linux-kernel,ver>=2.6.0,ver<=2.6.30
-Tags: 
+Tags:
 Rank: 1
 src-url: https://github.com/offensive-security/exploit-database-bin-sploits/raw/master/bin-sploits/9641.tar.gz
 exploit-db: 9641
@@ -437,13 +437,13 @@ EOF
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2013-1858]${txtrst} CLONE_NEWUSER|CLONE_FS
 Reqs: pkg=linux-kernel,ver=3.8,CONFIG_USER_NS=y
-Tags: 
+Tags:
 Rank: 1
 src-url: http://stealth.openwall.net/xSports/clown-newuser.c
 analysis-url: https://lwn.net/Articles/543273/
 exploit-db: 38390
 author: Sebastian Krahmer
-Comments: CONFIG_USER_NS needs to be enabled 
+Comments: CONFIG_USER_NS needs to be enabled
 EOF
 )
 
@@ -477,7 +477,7 @@ EOF
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2013-0268]${txtrst} msr
 Reqs: pkg=linux-kernel,ver>=2.6.18,ver<3.7.6
-Tags: 
+Tags:
 Rank: 1
 exploit-db: 27297
 EOF
@@ -486,7 +486,7 @@ EOF
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2013-1959]${txtrst} userns_root_sploit
 Reqs: pkg=linux-kernel,ver>=3.0.1,ver<3.8.9
-Tags: 
+Tags:
 Rank: 1
 analysis-url: http://www.openwall.com/lists/oss-security/2013/04/29/1
 exploit-db: 25450
@@ -539,7 +539,7 @@ EOF
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2014-2851]${txtrst} use-after-free in ping_init_sock() ${bldblu}(DoS)${txtrst}
 Reqs: pkg=linux-kernel,ver>=3.0.1,ver<=3.14
-Tags: 
+Tags:
 Rank: 0
 analysis-url: https://cyseclabs.com/page?n=02012016
 exploit-db: 32926
@@ -569,7 +569,7 @@ EOF
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2014-4943]${txtrst} PPPoL2TP ${bldblu}(DoS)${txtrst}
 Reqs: pkg=linux-kernel,ver>=3.2,ver<=3.15.6
-Tags: 
+Tags:
 Rank: 1
 analysis-url: https://cyseclabs.com/page?n=01102015
 exploit-db: 36267
@@ -579,7 +579,7 @@ EOF
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2014-5207]${txtrst} fuse_suid
 Reqs: pkg=linux-kernel,ver>=3.0.1,ver<=3.16.1
-Tags: 
+Tags:
 Rank: 1
 exploit-db: 34923
 EOF
@@ -600,7 +600,7 @@ EOF
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-3290]${txtrst} espfix64_NMI
 Reqs: pkg=linux-kernel,ver>=3.13,ver<4.1.6,x86_64
-Tags: 
+Tags:
 Rank: 1
 analysis-url: http://www.openwall.com/lists/oss-security/2015/08/04/8
 exploit-db: 37722
@@ -835,7 +835,7 @@ n=0
 EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2004-0186]${txtrst} samba
 Reqs: pkg=samba,ver<=2.2.8
-Tags: 
+Tags:
 Rank: 1
 exploit-db: 23674
 EOF
@@ -847,7 +847,7 @@ Reqs: pkg=udev,ver<141,cmd:[[ -f /etc/udev/rules.d/95-udev-late.rules || -f /lib
 Tags: ubuntu=8.10|9.04
 Rank: 1
 exploit-db: 8572
-Comments: Version<1.4.1 vulnerable but distros use own versioning scheme. Manual verification needed 
+Comments: Version<1.4.1 vulnerable but distros use own versioning scheme. Manual verification needed
 EOF
 )
 
@@ -893,7 +893,7 @@ EOF
 EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2012-0809]${txtrst} death_star (sudo)
 Reqs: pkg=sudo,ver>=1.8.0,ver<=1.8.3
-Tags: fedora=16 
+Tags: fedora=16
 Rank: 1
 analysis-url: http://seclists.org/fulldisclosure/2012/Jan/att-590/advisory_sudo.txt
 exploit-db: 18436
@@ -903,7 +903,7 @@ EOF
 EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2014-0476]${txtrst} chkrootkit
 Reqs: pkg=chkrootkit,ver<0.50
-Tags: 
+Tags:
 Rank: 1
 analysis-url: http://seclists.org/oss-sec/2014/q2/430
 exploit-db: 33899
@@ -991,7 +991,7 @@ Name: ${txtgrn}[CVE-2015-3246]${txtrst} userhelper
 Reqs: pkg=libuser,ver<=0.60
 Tags: RHEL=6{libuser:0.56.13-(4|5).el6},RHEL=6{libuser:0.60-5.el7},fedora=13|19|20|21|22
 Rank: 1
-analysis-url: https://www.qualys.com/2015/07/23/cve-2015-3245-cve-2015-3246/cve-2015-3245-cve-2015-3246.txt 
+analysis-url: https://www.qualys.com/2015/07/23/cve-2015-3245-cve-2015-3246/cve-2015-3245-cve-2015-3246.txt
 exploit-db: 37706
 Comments: RHEL 5 is also vulnerable, but installed version of glibc (2.5) lacks functions needed by roothelper.c
 EOF
@@ -1062,7 +1062,7 @@ EOF
 EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-1531]${txtrst} perl_startup (exim)
 Reqs: pkg=exim,ver<4.86.2
-Tags: 
+Tags:
 Rank: 1
 analysis-url: http://www.exim.org/static/doc/CVE-2016-1531.txt
 exploit-db: 39549
@@ -1072,7 +1072,7 @@ EOF
 EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-1531]${txtrst} perl_startup (exim) 2
 Reqs: pkg=exim,ver<4.86.2
-Tags: 
+Tags:
 Rank: 1
 analysis-url: http://www.exim.org/static/doc/CVE-2016-1531.txt
 exploit-db: 39535
@@ -1653,7 +1653,7 @@ parseUname() {
 getPkgList() {
     local distro=$1
     local pkglist_file=$2
-    
+
     # take package listing from provided file & detect if it's 'rpm -qa' listing or 'dpkg -l' or 'pacman -Q' listing of not recognized listing
     if [ "$opt_pkglist_file" = "true" -a -e "$pkglist_file" ]; then
 
@@ -1786,7 +1786,7 @@ checkRequirement() {
         # always true for Linux OS
         [ ${pkgName} == "linux-kernel" ] && return 0
 
-        # verify if package is present 
+        # verify if package is present
         pkg=$(echo "$PKG_LIST" | grep -E -i "^$pkgName-[0-9]+" | head -1)
         if [ -n "$pkg" ]; then
             return 0
@@ -1888,8 +1888,8 @@ getKernelConfig() {
 
     if [ -f /proc/config.gz ] ; then
         KCONFIG="zcat /proc/config.gz"
-    elif [ -f /boot/config-`uname -r` ] ; then
-        KCONFIG="cat /boot/config-`uname -r`"
+    elif [ -f "/boot/config-$(uname -r)" ] ; then
+        KCONFIG="cat /boot/config-$(uname -r)"
     elif [ -f "${KBUILD_OUTPUT:-/usr/src/linux}"/.config ] ; then
         KCONFIG="cat ${KBUILD_OUTPUT:-/usr/src/linux}/.config"
     else
@@ -2051,7 +2051,7 @@ while true; do
             exit 0
             ;;
         -h|--help)
-            usage 
+            usage
             exit 0
             ;;
         -f|--full)

--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -69,7 +69,7 @@ declare -a SORTED_EXPLOITS
 ############ LINUX KERNELSPACE EXPLOITS ####################
 n=0
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2004-1235]${txtrst} elflbl
 Reqs: pkg=linux-kernel,ver=2.4.29
 Tags:
@@ -80,7 +80,7 @@ exploit-db: 744
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2004-1235]${txtrst} uselib()
 Reqs: pkg=linux-kernel,ver=2.4.29
 Tags:
@@ -91,7 +91,7 @@ Comments: Known to work only for 2.4 series (even though 2.6 is also vulnerable)
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2004-1235]${txtrst} krad3
 Reqs: pkg=linux-kernel,ver>=2.6.5,ver<=2.6.11
 Tags:
@@ -100,7 +100,7 @@ exploit-db: 1397
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2004-0077]${txtrst} mremap_pte
 Reqs: pkg=linux-kernel,ver>=2.6.0,ver<=2.6.2
 Tags:
@@ -109,7 +109,7 @@ exploit-db: 160
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2006-2451]${txtrst} raptor_prctl
 Reqs: pkg=linux-kernel,ver>=2.6.13,ver<=2.6.17
 Tags:
@@ -118,7 +118,7 @@ exploit-db: 2031
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2006-2451]${txtrst} prctl
 Reqs: pkg=linux-kernel,ver>=2.6.13,ver<=2.6.17
 Tags:
@@ -127,7 +127,7 @@ exploit-db: 2004
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2006-2451]${txtrst} prctl2
 Reqs: pkg=linux-kernel,ver>=2.6.13,ver<=2.6.17
 Tags:
@@ -136,7 +136,7 @@ exploit-db: 2005
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2006-2451]${txtrst} prctl3
 Reqs: pkg=linux-kernel,ver>=2.6.13,ver<=2.6.17
 Tags:
@@ -145,7 +145,7 @@ exploit-db: 2006
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2006-2451]${txtrst} prctl4
 Reqs: pkg=linux-kernel,ver>=2.6.13,ver<=2.6.17
 Tags:
@@ -154,7 +154,7 @@ exploit-db: 2011
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2006-3626]${txtrst} h00lyshit
 Reqs: pkg=linux-kernel,ver>=2.6.8,ver<=2.6.16
 Tags:
@@ -164,7 +164,7 @@ exploit-db: 2013
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2008-0600]${txtrst} vmsplice1
 Reqs: pkg=linux-kernel,ver>=2.6.17,ver<=2.6.24
 Tags:
@@ -173,7 +173,7 @@ exploit-db: 5092
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2008-0600]${txtrst} vmsplice2
 Reqs: pkg=linux-kernel,ver>=2.6.23,ver<=2.6.24
 Tags:
@@ -182,7 +182,7 @@ exploit-db: 5093
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2008-4210]${txtrst} ftrex
 Reqs: pkg=linux-kernel,ver>=2.6.11,ver<=2.6.22
 Tags:
@@ -192,7 +192,7 @@ Comments: world-writable sgid directory and shell that does not drop sgid privs 
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2008-4210]${txtrst} exit_notify
 Reqs: pkg=linux-kernel,ver>=2.6.25,ver<=2.6.29
 Tags:
@@ -201,7 +201,7 @@ exploit-db: 8369
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2009-2692]${txtrst} sock_sendpage (simple version)
 Reqs: pkg=linux-kernel,ver>=2.6.0,ver<=2.6.30
 Tags: ubuntu=7.10,RHEL=4,fedora=4|5|6|7|8|9|10|11
@@ -211,7 +211,7 @@ Comments: Works for systems with /proc/sys/vm/mmap_min_addr equal to 0
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2009-2692,CVE-2009-1895]${txtrst} sock_sendpage
 Reqs: pkg=linux-kernel,ver>=2.6.0,ver<=2.6.30
 Tags: ubuntu=9.04
@@ -223,7 +223,7 @@ Comments: /proc/sys/vm/mmap_min_addr needs to equal 0 OR pulseaudio needs to be 
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2009-2692,CVE-2009-1895]${txtrst} sock_sendpage2
 Reqs: pkg=linux-kernel,ver>=2.6.0,ver<=2.6.30
 Tags:
@@ -234,7 +234,7 @@ Comments: Works for systems with /proc/sys/vm/mmap_min_addr equal to 0
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2009-2692,CVE-2009-1895]${txtrst} sock_sendpage3
 Reqs: pkg=linux-kernel,ver>=2.6.0,ver<=2.6.30
 Tags:
@@ -245,7 +245,7 @@ Comments: /proc/sys/vm/mmap_min_addr needs to equal 0 OR pulseaudio needs to be 
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2009-2692,CVE-2009-1895]${txtrst} sock_sendpage (ppc)
 Reqs: pkg=linux-kernel,ver>=2.6.0,ver<=2.6.30
 Tags: ubuntu=8.10,RHEL=4|5
@@ -255,7 +255,7 @@ Comments: /proc/sys/vm/mmap_min_addr needs to equal 0
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2009-2698]${txtrst} udp_sendmsg (by spender)
 Reqs: pkg=linux-kernel,ver>=2.6.1,ver<=2.6.19
 Tags:
@@ -265,7 +265,7 @@ exploit-db: 9574
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2009-2698]${txtrst} udp_sendmsg
 Reqs: pkg=linux-kernel,ver>=2.6.1,ver<=2.6.19
 Tags: debian=4
@@ -274,7 +274,7 @@ exploit-db: 9575
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2009-2698]${txtrst} ip_append_data
 Reqs: pkg=linux-kernel,ver>=2.6.1,ver<=2.6.19,x86
 Tags: fedora=4|5|6,RHEL=4
@@ -283,7 +283,7 @@ exploit-db: 9542
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2009-3547]${txtrst} pipe.c 1
 Reqs: pkg=linux-kernel,ver>=2.6.0,ver<=2.6.31
 Tags:
@@ -292,7 +292,7 @@ exploit-db: 33321
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2009-3547]${txtrst} pipe.c 2
 Reqs: pkg=linux-kernel,ver>=2.6.0,ver<=2.6.31
 Tags:
@@ -301,7 +301,7 @@ exploit-db: 33322
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2009-3547]${txtrst} pipe.c 3
 Reqs: pkg=linux-kernel,ver>=2.6.0,ver<=2.6.31
 Tags:
@@ -310,7 +310,7 @@ exploit-db: 10018
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2010-3301]${txtrst} ptrace_kmod2
 Reqs: pkg=linux-kernel,ver>=2.6.26,ver<=2.6.34
 Tags: debian=6.0{kernel:2.6.(32|33|34|35)-(1|2|trunk)-amd64},ubuntu=(10.04|10.10){kernel:2.6.(32|35)-(19|21|24)-server}
@@ -322,7 +322,7 @@ exploit-db: 15023
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2010-1146]${txtrst} reiserfs
 Reqs: pkg=linux-kernel,ver>=2.6.18,ver<=2.6.34
 Tags: ubuntu=9.10
@@ -331,7 +331,7 @@ exploit-db: 12130
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2010-2959]${txtrst} can_bcm
 Reqs: pkg=linux-kernel,ver>=2.6.18,ver<=2.6.36
 Tags: ubuntu=10.04{kernel:2.6.32-24-generic}
@@ -341,7 +341,7 @@ exploit-db: 14814
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2010-3904]${txtrst} rds
 Reqs: pkg=linux-kernel,ver>=2.6.30,ver<2.6.37
 Tags: debian=6.0{kernel:2.6.(31|32|34|35)-(1|trunk)-amd64},ubuntu=10.10|9.10,fedora=13{kernel:2.6.33.3-85.fc13.i686.PAE},ubuntu=10.04{kernel:2.6.32-(21|24)-generic}
@@ -354,7 +354,7 @@ exploit-db: 15285
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2010-3848,CVE-2010-3850,CVE-2010-4073]${txtrst} half_nelson
 Reqs: pkg=linux-kernel,ver>=2.6.0,ver<=2.6.36
 Tags: ubuntu=(10.04|9.10){kernel:2.6.(31|32)-(14|21)-server}
@@ -364,7 +364,7 @@ exploit-db: 17787
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[N/A]${txtrst} caps_to_root
 Reqs: pkg=linux-kernel,ver>=2.6.34,ver<=2.6.36,x86
 Tags: ubuntu=10.10
@@ -373,7 +373,7 @@ exploit-db: 15916
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[N/A]${txtrst} caps_to_root 2
 Reqs: pkg=linux-kernel,ver>=2.6.34,ver<=2.6.36
 Tags: ubuntu=10.10
@@ -382,7 +382,7 @@ exploit-db: 15944
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2010-4347]${txtrst} american-sign-language
 Reqs: pkg=linux-kernel,ver>=2.6.0,ver<=2.6.36
 Tags:
@@ -391,7 +391,7 @@ exploit-db: 15774
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2010-3437]${txtrst} pktcdvd
 Reqs: pkg=linux-kernel,ver>=2.6.0,ver<=2.6.36
 Tags: ubuntu=10.04
@@ -400,7 +400,7 @@ exploit-db: 15150
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2010-3081]${txtrst} video4linux
 Reqs: pkg=linux-kernel,ver>=2.6.0,ver<=2.6.33
 Tags: RHEL=5
@@ -409,7 +409,7 @@ exploit-db: 15024
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2012-0056]${txtrst} memodipper
 Reqs: pkg=linux-kernel,ver>=3.0.0,ver<=3.1.0
 Tags: ubuntu=(10.04|11.10){kernel:3.0.0-12-(generic|server)}
@@ -422,7 +422,7 @@ exploit-db: 18411
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2012-0056,CVE-2010-3849,CVE-2010-3850]${txtrst} full-nelson
 Reqs: pkg=linux-kernel,ver>=2.6.0,ver<=2.6.36
 Tags: ubuntu=(9.10|10.10){kernel:2.6.(31|35)-(14|19)-(server|generic)},ubuntu=10.04{kernel:2.6.32-(21|24)-server}
@@ -434,7 +434,7 @@ exploit-db: 15704
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2013-1858]${txtrst} CLONE_NEWUSER|CLONE_FS
 Reqs: pkg=linux-kernel,ver=3.8,CONFIG_USER_NS=y
 Tags:
@@ -447,7 +447,7 @@ Comments: CONFIG_USER_NS needs to be enabled
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2013-2094]${txtrst} perf_swevent
 Reqs: pkg=linux-kernel,ver>=2.6.32,ver<3.8.9,x86_64
 Tags: RHEL=6,ubuntu=12.04{kernel:3.2.0-(23|29)-generic},fedora=16{kernel:3.1.0-7.fc16.x86_64},fedora=17{kernel:3.3.4-5.fc17.x86_64},debian=7{kernel:3.2.0-4-amd64}
@@ -461,7 +461,7 @@ Comments: No SMEP/SMAP bypass
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2013-2094]${txtrst} perf_swevent 2
 Reqs: pkg=linux-kernel,ver>=2.6.32,ver<3.8.9,x86_64
 Tags: ubuntu=12.04{kernel:3.(2|5).0-(23|29)-generic}
@@ -474,7 +474,7 @@ Comments: No SMEP/SMAP bypass
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2013-0268]${txtrst} msr
 Reqs: pkg=linux-kernel,ver>=2.6.18,ver<3.7.6
 Tags:
@@ -483,7 +483,7 @@ exploit-db: 27297
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2013-1959]${txtrst} userns_root_sploit
 Reqs: pkg=linux-kernel,ver>=3.0.1,ver<3.8.9
 Tags:
@@ -493,7 +493,7 @@ exploit-db: 25450
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2013-2094]${txtrst} semtex
 Reqs: pkg=linux-kernel,ver>=2.6.32,ver<3.8.9
 Tags: RHEL=6
@@ -503,7 +503,7 @@ exploit-db: 25444
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2014-0038]${txtrst} timeoutpwn
 Reqs: pkg=linux-kernel,ver>=3.4.0,ver<=3.13.1,CONFIG_X86_X32=y
 Tags: ubuntu=13.10
@@ -515,7 +515,7 @@ Comments: CONFIG_X86_X32 needs to be enabled
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2014-0038]${txtrst} timeoutpwn 2
 Reqs: pkg=linux-kernel,ver>=3.4.0,ver<=3.13.1,CONFIG_X86_X32=y
 Tags: ubuntu=(13.04|13.10){kernel:3.(8|11).0-(12|15|19)-generic}
@@ -526,7 +526,7 @@ Comments: CONFIG_X86_X32 needs to be enabled
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2014-0196]${txtrst} rawmodePTY
 Reqs: pkg=linux-kernel,ver>=2.6.31,ver<=3.14.3
 Tags:
@@ -536,7 +536,7 @@ exploit-db: 33516
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2014-2851]${txtrst} use-after-free in ping_init_sock() ${bldblu}(DoS)${txtrst}
 Reqs: pkg=linux-kernel,ver>=3.0.1,ver<=3.14
 Tags:
@@ -546,7 +546,7 @@ exploit-db: 32926
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2014-4014]${txtrst} inode_capable
 Reqs: pkg=linux-kernel,ver>=3.0.1,ver<=3.13
 Tags: ubuntu=12.04
@@ -556,7 +556,7 @@ exploit-db: 33824
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2014-4699]${txtrst} ptrace/sysret
 Reqs: pkg=linux-kernel,ver>=3.0.1,ver<=3.8
 Tags: ubuntu=12.04
@@ -566,7 +566,7 @@ exploit-db: 34134
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2014-4943]${txtrst} PPPoL2TP ${bldblu}(DoS)${txtrst}
 Reqs: pkg=linux-kernel,ver>=3.2,ver<=3.15.6
 Tags:
@@ -576,7 +576,7 @@ exploit-db: 36267
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2014-5207]${txtrst} fuse_suid
 Reqs: pkg=linux-kernel,ver>=3.0.1,ver<=3.16.1
 Tags:
@@ -585,7 +585,7 @@ exploit-db: 34923
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-9322]${txtrst} BadIRET
 Reqs: pkg=linux-kernel,ver>=3.0.1,ver<3.17.5,x86_64
 Tags: RHEL<=7,fedora=20
@@ -597,7 +597,7 @@ author: Rafal 'n3rgal' Wojtczuk & Adam 'pi3' Zabrocki
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-3290]${txtrst} espfix64_NMI
 Reqs: pkg=linux-kernel,ver>=3.13,ver<4.1.6,x86_64
 Tags:
@@ -607,7 +607,7 @@ exploit-db: 37722
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[N/A]${txtrst} bluetooth
 Reqs: pkg=linux-kernel,ver<=2.6.11
 Tags:
@@ -616,7 +616,7 @@ exploit-db: 4756
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-1328]${txtrst} overlayfs
 Reqs: pkg=linux-kernel,ver>=3.13.0,ver<=3.19.0
 Tags: ubuntu=(12.04|14.04){kernel:3.13.0-(2|3|4|5)*-generic},ubuntu=(14.10|15.04){kernel:3.(13|16).0-*-generic}
@@ -628,7 +628,7 @@ exploit-db: 37292
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-8660]${txtrst} overlayfs (ovl_setattr)
 Reqs: pkg=linux-kernel,ver>=3.0.0,ver<=4.3.3
 Tags:
@@ -638,7 +638,7 @@ exploit-db: 39230
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-8660]${txtrst} overlayfs (ovl_setattr)
 Reqs: pkg=linux-kernel,ver>=3.0.0,ver<=4.3.3
 Tags: ubuntu=(14.04|15.10){kernel:4.2.0-(18|19|20|21|22)-generic}
@@ -648,7 +648,7 @@ exploit-db: 39166
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-0728]${txtrst} keyring
 Reqs: pkg=linux-kernel,ver>=3.10,ver<4.4.1
 Tags:
@@ -659,7 +659,7 @@ Comments: Exploit takes about ~30 minutes to run. Exploit is not reliable, see: 
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-2384]${txtrst} usb-midi
 Reqs: pkg=linux-kernel,ver>=3.0.0,ver<=4.4.8
 Tags: ubuntu=14.04,fedora=22
@@ -672,7 +672,7 @@ author: Andrey 'xairy' Konovalov
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-4997]${txtrst} target_offset
 Reqs: pkg=linux-kernel,ver>=4.4.0,ver<=4.4.0,cmd:grep -qi ip_tables /proc/modules
 Tags: ubuntu=16.04{kernel:4.4.0-21-generic}
@@ -684,7 +684,7 @@ author: Vitaly 'vnik' Nikolenko
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-4557]${txtrst} double-fdput()
 Reqs: pkg=linux-kernel,ver>=4.4,ver<4.5.5,CONFIG_BPF_SYSCALL=y,sysctl:kernel.unprivileged_bpf_disabled!=1
 Tags: ubuntu=16.04{kernel:4.4.0-(21|38|42|98|140)-generic}
@@ -697,7 +697,7 @@ author: Jann Horn
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-5195]${txtrst} dirtycow
 Reqs: pkg=linux-kernel,ver>=2.6.22,ver<=4.8.3
 Tags: debian=7|8,RHEL=5{kernel:2.6.(18|24|33)-*},RHEL=6{kernel:2.6.32-*|3.(0|2|6|8|10).*|2.6.33.9-rt31},RHEL=7{kernel:3.10.0-*|4.2.0-0.21.el7},ubuntu=16.04|14.04|12.04
@@ -709,7 +709,7 @@ author: Phil Oester
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-5195]${txtrst} dirtycow 2
 Reqs: pkg=linux-kernel,ver>=2.6.22,ver<=4.8.3
 Tags: debian=7|8,RHEL=5|6|7,ubuntu=14.04|12.04,ubuntu=10.04{kernel:2.6.32-21-generic},ubuntu=16.04{kernel:4.4.0-21-generic}
@@ -722,7 +722,7 @@ author: FireFart (author of exploit at EDB 40839); Gabriele Bonacini (author of 
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-8655]${txtrst} chocobo_root
 Reqs: pkg=linux-kernel,ver>=4.4.0,ver<4.9,CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1
 Tags: ubuntu=(14.04|16.04){kernel:4.4.0-(21|22|24|28|31|34|36|38|42|43|45|47|51)-generic}
@@ -735,7 +735,7 @@ author: rebel
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-9793]${txtrst} SO_{SND|RCV}BUFFORCE
 Reqs: pkg=linux-kernel,ver>=3.11,ver<4.8.14,CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1
 Tags:
@@ -748,7 +748,7 @@ author: Andrey 'xairy' Konovalov
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2017-6074]${txtrst} dccp
 Reqs: pkg=linux-kernel,ver>=2.6.18,ver<=4.9.11,CONFIG_IP_DCCP=[my]
 Tags: ubuntu=(14.04|16.04){kernel:4.4.0-62-generic}
@@ -760,7 +760,7 @@ author: Andrey 'xairy' Konovalov
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2017-7308]${txtrst} af_packet
 Reqs: pkg=linux-kernel,ver>=3.2,ver<=4.10.6,CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1
 Tags: ubuntu=16.04{kernel:4.8.0-(34|36|39|41|42|44|45)-generic}
@@ -775,7 +775,7 @@ author: Andrey 'xairy' Konovalov (orginal exploit author); Brendan Coles (author
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2017-16995]${txtrst} eBPF_verifier
 Reqs: pkg=linux-kernel,ver>=4.4,ver<=4.14.8,CONFIG_BPF_SYSCALL=y,sysctl:kernel.unprivileged_bpf_disabled!=1
 Tags: debian=9.0{kernel:4.9.0-3-amd64},fedora=25|26|27,ubuntu=14.04{kernel:4.4.0-89-generic},ubuntu=(16.04|17.04){kernel:4.(8|10).0-(19|28|45)-generic}
@@ -788,7 +788,7 @@ author: Rick Larabee
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2017-1000112]${txtrst} NETIF_F_UFO
 Reqs: pkg=linux-kernel,ver>=4.4,ver<=4.13,CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1
 Tags: ubuntu=14.04{kernel:4.4.0-*},ubuntu=16.04{kernel:4.8.0-*}
@@ -803,7 +803,7 @@ author: Andrey 'xairy' Konovalov (orginal exploit author); Brendan Coles (author
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2017-1000253]${txtrst} PIE_stack_corruption
 Reqs: pkg=linux-kernel,ver>=3.2,ver<=4.13,x86_64
 Tags: RHEL=6,RHEL=7{kernel:3.10.0-514.21.2|3.10.0-514.26.1}
@@ -816,7 +816,7 @@ Comments:
 EOF
 )
 
-EXPLOITS[((n++))]=$(cat <<EOF
+EXPLOITS[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2018-18955]${txtrst} subuid_shell
 Reqs: pkg=linux-kernel,ver>=4.15,ver<=4.19.2,CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1,cmd:[ -u /usr/bin/newuidmap ],cmd:[ -u /usr/bin/newgidmap ]
 Tags: ubuntu=18.04{kernel:4.15.0-20-generic},fedora=28{kernel:4.16.3-301.fc28}
@@ -832,7 +832,7 @@ EOF
 ############ USERSPACE EXPLOITS ###########################
 n=0
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2004-0186]${txtrst} samba
 Reqs: pkg=samba,ver<=2.2.8
 Tags:
@@ -841,7 +841,7 @@ exploit-db: 23674
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2009-1185]${txtrst} udev
 Reqs: pkg=udev,ver<141,cmd:[[ -f /etc/udev/rules.d/95-udev-late.rules || -f /lib/udev/rules.d/95-udev-late.rules ]]
 Tags: ubuntu=8.10|9.04
@@ -851,7 +851,7 @@ Comments: Version<1.4.1 vulnerable but distros use own versioning scheme. Manual
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2009-1185]${txtrst} udev 2
 Reqs: pkg=udev,ver<141
 Tags:
@@ -861,7 +861,7 @@ Comments: SSH access to non privileged user is needed. Version<1.4.1 vulnerable 
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2010-0832]${txtrst} PAM MOTD
 Reqs: pkg=libpam-modules,ver<=1.1.1
 Tags: ubuntu=9.10|10.04
@@ -871,7 +871,7 @@ Comments: SSH access to non privileged user is needed
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2010-4170]${txtrst} SystemTap
 Reqs: pkg=systemtap,ver<=1.3
 Tags: RHEL=5{systemtap:1.1-3.el5},fedora=13{systemtap:1.2-1.fc13}
@@ -881,7 +881,7 @@ exploit-db: 15620
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2011-1485]${txtrst} pkexec
 Reqs: pkg=polkit,ver=0.96
 Tags: RHEL=6,ubuntu=10.04|10.10
@@ -890,7 +890,7 @@ exploit-db: 17942
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2012-0809]${txtrst} death_star (sudo)
 Reqs: pkg=sudo,ver>=1.8.0,ver<=1.8.3
 Tags: fedora=16
@@ -900,7 +900,7 @@ exploit-db: 18436
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2014-0476]${txtrst} chkrootkit
 Reqs: pkg=chkrootkit,ver<0.50
 Tags:
@@ -911,7 +911,7 @@ Comments: Rooting depends on the crontab (up to one day of delay)
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2014-5119]${txtrst} __gconv_translit_find
 Reqs: pkg=glibc|libc6,x86
 Tags: debian=6
@@ -922,7 +922,7 @@ exploit-db: 34421
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-1862]${txtrst} newpid (abrt)
 Reqs: pkg=abrt,cmd:grep -qi abrt /proc/sys/kernel/core_pattern
 Tags: fedora=20
@@ -933,7 +933,7 @@ exploit-db: 36746
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-3315]${txtrst} raceabrt
 Reqs: pkg=abrt,cmd:grep -qi abrt /proc/sys/kernel/core_pattern
 Tags: fedora=19{abrt:2.1.5-1.fc19},fedora=20{abrt:2.2.2-2.fc20},fedora=21{abrt:2.3.0-3.fc21},RHEL=7{abrt:2.1.11-12.el7}
@@ -945,7 +945,7 @@ author: Tavis Ormandy
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-1318]${txtrst} newpid (apport)
 Reqs: pkg=apport,ver>=2.13,ver<=2.17,cmd:grep -qi apport /proc/sys/kernel/core_pattern
 Tags: ubuntu=14.04
@@ -956,7 +956,7 @@ exploit-db: 36746
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-1318]${txtrst} newpid (apport) 2
 Reqs: pkg=apport,ver>=2.13,ver<=2.17,cmd:grep -qi apport /proc/sys/kernel/core_pattern
 Tags: ubuntu=14.04.2
@@ -966,7 +966,7 @@ exploit-db: 36782
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-3202]${txtrst} fuse (fusermount)
 Reqs: pkg=fuse,ver<2.9.3
 Tags: debian=7.0|8.0,ubuntu=*
@@ -977,7 +977,7 @@ Comments: Needs cron or system admin interaction
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-1815]${txtrst} setroubleshoot
 Reqs: pkg=setroubleshoot,ver<3.2.22
 Tags: fedora=21
@@ -986,7 +986,7 @@ exploit-db: 36564
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-3246]${txtrst} userhelper
 Reqs: pkg=libuser,ver<=0.60
 Tags: RHEL=6{libuser:0.56.13-(4|5).el6},RHEL=6{libuser:0.60-5.el7},fedora=13|19|20|21|22
@@ -997,7 +997,7 @@ Comments: RHEL 5 is also vulnerable, but installed version of glibc (2.5) lacks 
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-5287]${txtrst} abrt/sosreport-rhel7
 Reqs: pkg=abrt,cmd:grep -qi abrt /proc/sys/kernel/core_pattern
 Tags: RHEL=7{abrt:2.1.11-12.el7}
@@ -1009,7 +1009,7 @@ author: rebel
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-6565]${txtrst} not_an_sshnuke
 Reqs: pkg=openssh-server,ver>=6.8,ver<=6.9
 Tags:
@@ -1021,7 +1021,7 @@ Comments: Needs admin interaction (root user needs to login via ssh to trigger e
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2015-8612]${txtrst} blueman set_dhcp_handler d-bus privesc
 Reqs: pkg=blueman,ver<2.0.3
 Tags: debian=8{blueman:1.23}
@@ -1033,7 +1033,7 @@ Comments: Distros use own versioning scheme. Manual verification needed.
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-1240]${txtrst} tomcat-rootprivesc-deb.sh
 Reqs: pkg=tomcat
 Tags: debian=8,ubuntu=16.04
@@ -1046,7 +1046,7 @@ Comments: Affects only Debian-based distros
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-1247]${txtrst} nginxed-root.sh
 Reqs: pkg=nginx|nginx-full,ver<1.10.3
 Tags: debian=8,ubuntu=14.04|16.04|16.10
@@ -1059,7 +1059,7 @@ Comments: Rooting depends on cron.daily (up to 24h of delay). Affected: deb8: <1
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-1531]${txtrst} perl_startup (exim)
 Reqs: pkg=exim,ver<4.86.2
 Tags:
@@ -1069,7 +1069,7 @@ exploit-db: 39549
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-1531]${txtrst} perl_startup (exim) 2
 Reqs: pkg=exim,ver<4.86.2
 Tags:
@@ -1079,7 +1079,7 @@ exploit-db: 39535
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-4989]${txtrst} setroubleshoot 2
 Reqs: pkg=setroubleshoot
 Tags: RHEL=6|7
@@ -1090,7 +1090,7 @@ exploit-db:
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-5425]${txtrst} tomcat-RH-root.sh
 Reqs: pkg=tomcat
 Tags: RHEL=7
@@ -1103,7 +1103,7 @@ Comments: Affects only RedHat-based distros
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-6663,CVE-2016-6664|CVE-2016-6662]${txtrst} mysql-exploit-chain
 Reqs: pkg=mysql-server|mariadb-server,ver<5.5.52
 Tags: ubuntu=16.04.1
@@ -1116,7 +1116,7 @@ Comments: Also MariaDB ver<10.1.18 and ver<10.0.28 affected
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-9566]${txtrst} nagios-root-privesc
 Reqs: pkg=nagios,ver<4.2.4
 Tags:
@@ -1129,7 +1129,7 @@ Comments: Allows priv escalation from nagios user or nagios group
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2017-0358]${txtrst} ntfs-3g-modprobe
 Reqs: pkg=ntfs-3g,ver<2017.4
 Tags: ubuntu=16.04{ntfs-3g:2015.3.14AR.1-1build1},debian=7.0{ntfs-3g:2012.1.15AR.5-2.1+deb7u2},debian=8.0{ntfs-3g:2014.2.15AR.2-1+deb8u2}
@@ -1142,7 +1142,7 @@ Comments: Distros use own versioning scheme. Manual verification needed. Linux h
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2017-5899]${txtrst} s-nail-privget
 Reqs: pkg=s-nail,ver<14.8.16
 Tags: ubuntu=16.04,manjaro=16.10
@@ -1155,7 +1155,7 @@ Comments: Distros use own versioning scheme. Manual verification needed.
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2017-1000367]${txtrst} Sudoer-to-root
 Reqs: pkg=sudo,ver<=1.8.20,cmd:[ -f /usr/sbin/getenforce ]
 Tags: RHEL=7{sudo:1.8.6p7}
@@ -1168,7 +1168,7 @@ Comments: Needs to be sudoer. Works only on SELinux enabled systems
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2017-1000367]${txtrst} sudopwn
 Reqs: pkg=sudo,ver<=1.8.20,cmd:[ -f /usr/sbin/getenforce ]
 Tags:
@@ -1181,7 +1181,7 @@ Comments: Needs to be sudoer. Works only on SELinux enabled systems
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2017-1000366,CVE-2017-1000370]${txtrst} linux_ldso_hwcap
 Reqs: pkg=glibc|libc6,ver<=2.25,x86
 Tags:
@@ -1194,7 +1194,7 @@ Comments: Uses "Stack Clash" technique, works against most SUID-root binaries
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2017-1000366,CVE-2017-1000371]${txtrst} linux_ldso_dynamic
 Reqs: pkg=glibc|libc6,ver<=2.25,x86
 Tags: debian=9|10,ubuntu=14.04.5|16.04.2|17.04,fedora=23|24|25
@@ -1207,7 +1207,7 @@ Comments: Uses "Stack Clash" technique, works against most SUID-root PIEs
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2017-1000366,CVE-2017-1000379]${txtrst} linux_ldso_hwcap_64
 Reqs: pkg=glibc|libc6,ver<=2.25,x86_64
 Tags: debian=7.7|8.5|9.0,ubuntu=14.04.2|16.04.2|17.04,fedora=22|25,centos=7.3.1611
@@ -1220,7 +1220,7 @@ Comments: Uses "Stack Clash" technique, works against most SUID-root binaries
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2017-1000370,CVE-2017-1000371]${txtrst} linux_offset2lib
 Reqs: pkg=glibc|libc6,ver<=2.25,x86
 Tags:
@@ -1233,7 +1233,7 @@ Comments: Uses "Stack Clash" technique
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2018-1000001]${txtrst} RationalLove
 Reqs: pkg=glibc|libc6,ver<2.27,CONFIG_USER_NS=y,sysctl:kernel.unprivileged_userns_clone==1,x86_64
 Tags: debian=9{libc6:2.24-11+deb9u1},ubuntu=16.04.3{libc6:2.23-0ubuntu9}
@@ -1247,7 +1247,7 @@ author: halfdog
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2018-10900]${txtrst} vpnc_privesc.py
 Reqs: pkg=networkmanager-vpnc|network-manager-vpnc,ver<1.2.6
 Tags: ubuntu=16.04{network-manager-vpnc:1.1.93-1},debian=9.0{network-manager-vpnc:1.2.4-4},manjaro=17
@@ -1260,7 +1260,7 @@ Comments: Distros use own versioning scheme. Manual verification needed.
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2018-14665]${txtrst} raptor_xorgy
 Reqs: pkg=xorg-x11-server-Xorg,cmd:[ -u /usr/bin/Xorg ]
 Tags: centos=7.4
@@ -1272,7 +1272,7 @@ Comments: X.Org Server before 1.20.3 is vulnerable. Distros use own versioning s
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2019-7304]${txtrst} dirty_sock
 Reqs: pkg=snapd,ver<2.37,cmd:[ -S /run/snapd.socket ]
 Tags: ubuntu=18.10,mint=19
@@ -1286,7 +1286,7 @@ Comments: Distros use own versioning scheme. Manual verification needed.
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2019-10149]${txtrst} raptor_exim_wiz
 Reqs: pkg=exim|exim4,ver>=4.87,ver<=4.91
 Tags:
@@ -1297,7 +1297,7 @@ author: raptor
 EOF
 )
 
-EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+EXPLOITS_USERSPACE[n++]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2019-12181]${txtrst} Serv-U FTP Server
 Reqs: cmd:[ -u /usr/local/Serv-U/Serv-U ]
 Tags: debian=9
@@ -1316,12 +1316,12 @@ EOF
 ###########################################################
 n=0
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 section: Mainline kernel protection mechanisms:
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Kernel Page Table Isolation (PTI) support
 available: ver>=4.15
 enabled: cmd:grep -Eqi '\spti' /proc/cpuinfo
@@ -1329,21 +1329,21 @@ analysis-url: https://github.com/mzet-/les-res/blob/master/features/pti.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: GCC stack protector support
 available: CONFIG_HAVE_STACKPROTECTOR=y
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/stackprotector-regular.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: GCC stack protector STRONG support
 available: CONFIG_STACKPROTECTOR_STRONG=y,ver>=3.14
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/stackprotector-strong.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Low address space to protect from user allocation
 available: CONFIG_DEFAULT_MMAP_MIN_ADDR=[0-9]+
 enabled: sysctl:vm.mmap_min_addr!=0
@@ -1351,7 +1351,7 @@ analysis-url: https://github.com/mzet-/les-res/blob/master/features/mmap_min_add
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Prevent users from using ptrace to examine the memory and state of their processes
 available: CONFIG_SECURITY_YAMA=y
 enabled: sysctl:kernel.yama.ptrace_scope!=0
@@ -1359,7 +1359,7 @@ analysis-url: https://github.com/mzet-/les-res/blob/master/features/yama_ptrace_
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Restrict unprivileged access to kernel syslog
 available: CONFIG_SECURITY_DMESG_RESTRICT=y,ver>=2.6.37
 enabled: sysctl:kernel.dmesg_restrict!=0
@@ -1367,112 +1367,112 @@ analysis-url: https://github.com/mzet-/les-res/blob/master/features/dmesg_restri
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Randomize the address of the kernel image (KASLR)
 available: CONFIG_RANDOMIZE_BASE=y
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/kaslr.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Hardened user copy support
 available: CONFIG_HARDENED_USERCOPY=y
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/hardened_usercopy.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Make kernel text and rodata read-only
 available: CONFIG_STRICT_KERNEL_RWX=y
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/strict_kernel_rwx.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Set loadable kernel module data as NX and text as RO
 available: CONFIG_STRICT_MODULE_RWX=y
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/strict_module_rwx.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: BUG() conditions reporting
 available: CONFIG_BUG=y
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/bug.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Additional 'cred' struct checks
 available: CONFIG_DEBUG_CREDENTIALS=y
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/debug_credentials.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Sanity checks for notifier call chains
 available: CONFIG_DEBUG_NOTIFIERS=y
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/debug_notifiers.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Extended checks for linked-lists walking
 available: CONFIG_DEBUG_LIST=y
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/debug_list.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Checks on scatter-gather tables
 available: CONFIG_DEBUG_SG=y
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/debug_sg.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Checks for data structure corruptions
 available: CONFIG_BUG_ON_DATA_CORRUPTION=y
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/bug_on_data_corruption.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Checks for a stack overrun on calls to 'schedule'
 available: CONFIG_SCHED_STACK_END_CHECK=y
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/sched_stack_end_check.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Freelist order randomization on new pages creation
 available: CONFIG_SLAB_FREELIST_RANDOM=y
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/slab_freelist_random.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Freelist metadata hardening
 available: CONFIG_SLAB_FREELIST_HARDENED=y
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/slab_freelist_hardened.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Allocator validation checking
 available: CONFIG_SLUB_DEBUG_ON=y,cmd:! grep 'slub_debug=-' /proc/cmdline
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/slub_debug.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Virtually-mapped kernel stacks with guard pages
 available: CONFIG_VMAP_STACK=y
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/vmap_stack.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Pages poisoning after free_pages() call
 available: CONFIG_PAGE_POISONING=y
 enabled: cmd: grep 'page_poison=1' /proc/cmdline
@@ -1480,40 +1480,40 @@ analysis-url: https://github.com/mzet-/les-res/blob/master/features/page_poisoni
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Using 'refcount_t' instead of 'atomic_t'
 available: CONFIG_REFCOUNT_FULL=y
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/refcount_full.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Hardening common str/mem functions against buffer overflows
 available: CONFIG_FORTIFY_SOURCE=y
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/fortify_source.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Restrict /dev/mem access
 available: CONFIG_STRICT_DEVMEM=y
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/strict_devmem.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Restrict I/O access to /dev/mem
 available: CONFIG_IO_STRICT_DEVMEM=y
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/io_strict_devmem.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 section: Hardware-based protection features:
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Supervisor Mode Execution Protection (SMEP) support
 available: ver>=3.0
 enabled: cmd:grep -qi smep /proc/cpuinfo
@@ -1521,7 +1521,7 @@ analysis-url: https://github.com/mzet-/les-res/blob/master/features/smep.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Supervisor Mode Access Prevention (SMAP) support
 available: ver>=3.7
 enabled: cmd:grep -qi smap /proc/cpuinfo
@@ -1529,38 +1529,38 @@ analysis-url: https://github.com/mzet-/les-res/blob/master/features/smap.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 section: 3rd party kernel protection mechanisms:
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Grsecurity
 available: CONFIG_GRKERNSEC=y
 enabled: cmd:test -c /dev/grsec
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: PaX
 available: CONFIG_PAX=y
 enabled: cmd:test -x /sbin/paxctl
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Linux Kernel Runtime Guard (LKRG) kernel module
 enabled: cmd:test -d /proc/sys/lkrg
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/lkrg.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 section: Attack Surface:
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: User namespaces for unprivileged accounts
 available: CONFIG_USER_NS=y
 enabled: sysctl:kernel.unprivileged_userns_clone==1
@@ -1568,7 +1568,7 @@ analysis-url: https://github.com/mzet-/les-res/blob/master/features/user_ns.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Unprivileged access to bpf() system call
 available: CONFIG_BPF_SYSCALL=y
 enabled: sysctl:kernel.unprivileged_bpf_disabled!=1
@@ -1576,7 +1576,7 @@ analysis-url: https://github.com/mzet-/les-res/blob/master/features/bpf_syscall.
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Syscalls filtering
 available: CONFIG_SECCOMP=y
 enabled: cmd:grep -i Seccomp /proc/self/status | awk '{print \$2}'
@@ -1584,14 +1584,14 @@ analysis-url: https://github.com/mzet-/les-res/blob/master/features/bpf_syscall.
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Support for /dev/mem access
 available: CONFIG_DEVMEM=y
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/devmem.md
 EOF
 )
 
-FEATURES[((n++))]=$(cat <<EOF
+FEATURES[n++]=$(cat <<EOF
 feature: Support for /dev/kmem access
 available: CONFIG_DEVKMEM=y
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/devkmem.md
@@ -1600,7 +1600,7 @@ EOF
 
 
 version() {
-    echo "linux-exploit-suggester "$VERSION", mzet, https://z-labs.eu, March 2019"
+    echo "linux-exploit-suggester $VERSION, mzet, https://z-labs.eu, March 2019"
 }
 
 usage() {
@@ -2206,8 +2206,7 @@ else
         KERNEL=""
         #TODO: extract machine arch from package listing
         ARCH=""
-        unset EXPLOITS
-        declare -A EXPLOITS
+        declare -a EXPLOITS=()
         getPkgList "" "$PKGLIST_FILE"
 
         # additional checks are not applicable for this mode
@@ -2237,13 +2236,11 @@ echo -e "Package listing: $([ -n "$pkgListFile" ] && echo -e "$pkgListFile" || e
 
 # handle --kernelspacy-only & --userspace-only filter options
 if [ "$opt_kernel_only" = "true" -o -z "$PKG_LIST" ]; then
-    unset EXPLOITS_USERSPACE
-    declare -A EXPLOITS_USERSPACE
+    declare -a EXPLOITS_USERSPACE=()
 fi
 
 if [ "$opt_userspace_only" = "true" ]; then
-    unset EXPLOITS
-    declare -A EXPLOITS
+    declare -a EXPLOITS=()
 fi
 
 echo


### PR DESCRIPTION
Comment variables, simplify arrays index increment, don't use ``.
Also, empty arrays in one line with -a, associative array (-A) with n++ probably wouldn't work anyway.