### PR TITLE
Update PTRACE_TRACEME exploit reqs to use x86_64

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -831,7 +831,7 @@ EOF
 
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2019-13272]${txtrst} PTRACE_TRACEME
-Reqs: pkg=linux-kernel,ver>=4,ver<5.1.17,sysctl:kernel.yama.ptrace_scope==0
+Reqs: pkg=linux-kernel,ver>=4,ver<5.1.17,sysctl:kernel.yama.ptrace_scope==0,x86_64
 Tags: ubuntu=16.04{kernel:4.15.0-*},ubuntu=18.04{kernel:4.15.0-*},debian=9{kernel:4.9.0-*},debian=10{kernel:4.19.0-*},fedora=30{kernel:5.0.9-*}
 Rank: 1
 analysis-url: https://bugs.chromium.org/p/project-zero/issues/detail?id=1903


### PR DESCRIPTION
Exploit is 64-bit only