### PR TITLE
Adjust requirements for CVE-2018-5333

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -818,8 +818,8 @@ EOF
 
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2018-5333]${txtrst} rds_atomic_free_op NULL pointer dereference
-Reqs: pkg=linux-kernel,ver=4.4.0,cmd:grep -qi rds /proc/modules,x86_64
-Tags: ubuntu=16.04{kernel:4.4.0-(112|116)-generic}
+Reqs: pkg=linux-kernel,ver>=4.4,ver<=4.14.13,cmd:grep -qi rds /proc/modules,x86_64
+Tags: ubuntu=16.04{kernel:4.4.0|4.8.0}
 Rank: 1
 src-url: https://gist.githubusercontent.com/wbowling/9d32492bd96d9e7c3bf52e23a0ac30a4/raw/959325819c78248a6437102bb289bb8578a135cd/cve-2018-5333-poc.c
 ext-url: https://raw.githubusercontent.com/bcoles/kernel-exploits/master/CVE-2018-5333/cve-2018-5333.c


### PR DESCRIPTION
Linux RDS rds_atomic_free_op NULL pointer dereference (CVE-2018-5333).

Exploit targets:
 - Ubuntu 16.04 kernels 4.4.0 <= 4.4.0-116
 - Ubuntu 16.04 kernels 4.8.0 <= 4.8.0-54