### PR TITLE
Add GNU Mailutils maidag url local root (CVE-2019-18862)

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -1347,6 +1347,17 @@ author: Guy Levin (orginal exploit author); Brendan Coles (author of exploit upd
 Comments: Modified version at 'ext-url' uses bash exec technique, rather than compiling with gcc.
 EOF
 )
+EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+Name: ${txtgrn}[CVE-2019-18862]${txtrst} GNU Mailutils 2.0 <= 3.7 maidag url local root (CVE-2019-18862)
+Reqs: cmd:[ -u /usr/local/sbin/maidag ]
+Tags: 
+Rank: 1
+analysis-url: https://www.mike-gualtieri.com/posts/finding-a-decade-old-flaw-in-gnu-mailutils
+ext-url: https://github.com/bcoles/local-exploits/raw/master/CVE-2019-18862/exploit.cron.sh
+src-url: https://github.com/bcoles/local-exploits/raw/master/CVE-2019-18862/exploit.ldpreload.sh
+author: bcoles
+EOF
+)
 
 ###########################################################
 ## security related HW/kernel features


### PR DESCRIPTION
Exploitable only when `/usr/local/sbin/maidag` is set-uid root.

Mailutils, when installed from software package repositories,
usually does not set `maidag` set-uid root.

The issue was patched by removing `maidag`.