### PR TITLE
Fix tested versions for CVE-2016-4557

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -687,7 +687,7 @@ EOF
 EXPLOITS[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2016-4557]${txtrst} double-fdput()
 Reqs: pkg=linux-kernel,ver>=4.4,ver<4.5.5,CONFIG_BPF_SYSCALL=y,sysctl:kernel.unprivileged_bpf_disabled!=1
-Tags: ubuntu=16.04{kernel:4.4.0-(21|38|42|98|140)-generic}
+Tags: ubuntu=16.04{kernel:4.4.0-21-generic}
 Rank: 1
 analysis-url: https://bugs.chromium.org/p/project-zero/issues/detail?id=808
 src-url: https://github.com/offensive-security/exploit-database-bin-sploits/raw/master/bin-sploits/39772.zip


### PR DESCRIPTION
The listed tested versions don't work. When testing, I overlooked the backdoor.

Exploitation leaves behind a backdoor, which is leveraged by subsequent exploitation attempts, invalidating the tests.
