### PR TITLE
Add Wing FTP Server <= 6.2.5 LPE (CVE-2020-9470)

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -1371,6 +1371,19 @@ Comments: sudo configuration requires pwfeedback to be enabled.
 EOF
 )
 
+EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+Name: ${txtgrn}[CVE-2020-9470]${txtrst} Wing FTP Server <= 6.2.5 LPE
+Reqs: cmd:[ -x /etc/init.d/wftpserver ]
+Tags: ubuntu=18
+Rank: 1
+analysis-url: https://www.hooperlabs.xyz/disclosures/cve-2020-9470.php
+src-url: https://www.hooperlabs.xyz/disclosures/cve-2020-9470.sh
+exploit-db: 48154
+author: Cary Cooper
+Comments: Requires an administrator to login via the web interface.
+EOF
+)
+
 ###########################################################
 ## security related HW/kernel features
 ###########################################################


### PR DESCRIPTION
```
[+] [CVE-2020-9470] Wing FTP Server <= 6.2.5 LPE

   Details: https://www.hooperlabs.xyz/disclosures/cve-2020-9470.php
   Exposure: probable
   Tags: [ ubuntu=18 ]
   Download URL: https://www.hooperlabs.xyz/disclosures/cve-2020-9470.sh
   Comments: Requires an administrator to login via the web interface.
```
