### PR TITLE
Ensure at least one src-url/bin-url/exploit-db is present for each exploit

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -2489,9 +2489,10 @@ for EXP_TEMP in "${SORTED_EXPLOITS[@]}"; do
 	# exploit name without CVE number and without commonly used special chars
 	name=$(echo "$NAME" | cut -d' ' -f 2- | tr -d ' ()/')
 
+	bin_url=$(echo "$EXP" | grep "bin-url: " | awk '{print $2}')
 	src_url=$(echo "$EXP" | grep "src-url: " | awk '{print $2}')
 	[ -z "$src_url" ] && [ -n "$EXPLOIT_DB" ] && src_url="https://www.exploit-db.com/download/$EXPLOIT_DB"
-	[ -z "$src_url" ] && exitWithErrMsg "Both 'src-url' and 'exploit-db' entries are empty for '$NAME' exploit - fix that. Aborting."
+	[ -z "$src_url" ] && [ -z "$bin_url" ] && exitWithErrMsg "'src-url' / 'bin-url' / 'exploit-db' entries are all empty for '$NAME' exploit - fix that. Aborting."
 
 	if [ -n "$analysis_url" ]; then
         details="$analysis_url"


### PR DESCRIPTION
Fix #74

Unfortunately one exploit has no publicly available source (yet). This is undesirable, but it seems like the easiest solution for now is to ensure one of `src-url` / `bin-url` / `exploit-db`, rather than requiring one of `src-url` / `exploit-db`.
