### PR TITLE
Update comments for reiserfs (CVE-2010-1146)

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -327,7 +327,10 @@ Name: ${txtgrn}[CVE-2010-1146]${txtrst} reiserfs
 Reqs: pkg=linux-kernel,ver>=2.6.18,ver<=2.6.34
 Tags: ubuntu=9.10
 Rank: 1
+analysis-url: https://jon.oberheide.org/blog/2010/04/10/reiserfs-reiserfs_priv-vulnerability/
+src-url: https://jon.oberheide.org/files/team-edward.py
 exploit-db: 12130
+comments: Requires a ReiserFS filesystem mounted with extended attributes
 EOF
 )
 


### PR DESCRIPTION
Untested. Based on comments from the [analysis](https://jon.oberheide.org/blog/2010/04/10/reiserfs-reiserfs_priv-vulnerability/) and [exploit](https://www.exploit-db.com/exploits/12130) :

```
Notes:
    Obviously requires a ReiserFS filesystem mounted with extended attributes.
    Tested on Ubuntu Jaunty 9.10.
```
