### PR TITLE
Add linux-iscsi (CVE-2021-27365)

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -892,6 +892,18 @@ author: Vitaly 'vnik' Nikolenko
 EOF
 )
 
+EXPLOITS[((n++))]=$(cat <<EOF
+Name: ${txtgrn}[CVE-2021-27365]${txtrst} linux-iscsi
+Reqs: pkg=linux-kernel,ver<=5.11.3,CONFIG_SLAB_FREELIST_HARDENED!=y
+Tags: RHEL=8
+Rank: 1
+analysis-url: https://blog.grimm-co.com/2021/03/new-old-bugs-in-linux-kernel.html
+src-url: https://codeload.github.com/grimm-co/NotQuite0DayFriday/zip/trunk
+Comments: CONFIG_SLAB_FREELIST_HARDENED must not be enabled
+author: GRIMM
+EOF
+)
+
 ############ USERSPACE EXPLOITS ###########################
 n=0
 


### PR DESCRIPTION
Unfortunately `src-url` points to the entire repository. There's no direct link to download only the folder containing the iSCSI exploit.