### PR TITLE
Add worawit's sudo Baron Samedit (CVE-2021-3156) exploit

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -1444,6 +1444,17 @@ EOF
 )
 
 EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
+Name: ${txtgrn}[CVE-2021-3156]${txtrst} sudo Baron Samedit 2
+Reqs: pkg=sudo,ver<1.9.5p2
+Tags: centos=6|7|8,ubuntu=14|16|17|18|19|20, debian=9|10
+Rank: 1
+analysis-url: https://www.qualys.com/2021/01/26/cve-2021-3156/baron-samedit-heap-based-overflow-sudo.txt
+src-url: https://codeload.github.com/worawit/CVE-2021-3156/zip/main
+author: worawit
+EOF
+)
+
+EXPLOITS_USERSPACE[((n++))]=$(cat <<EOF
 Name: ${txtgrn}[CVE-2017-5618]${txtrst} setuid screen v4.5.0 LPE
 Reqs: pkg=screen,ver==4.5.0
 Tags: 


### PR DESCRIPTION
Regarding the tags:

```
Tags: centos=6|7|8,ubuntu=14|16|17|18|19|20, debian=9|10
```

I've verified the exploit works on CentOS 8.1. Apparently it works on the others. Presumably it also works on Ubuntu 15 (not listed above) but the exploit author didn't specify.
