### PR TITLE
CVE-2012-0056: Fix 'mempodipper' typo

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -434,7 +434,7 @@ EOF
 )
 
 EXPLOITS[((n++))]=$(cat <<EOF
-Name: ${txtgrn}[CVE-2012-0056]${txtrst} memodipper
+Name: ${txtgrn}[CVE-2012-0056]${txtrst} mempodipper
 Reqs: pkg=linux-kernel,ver>=3.0.0,ver<=3.1.0
 Tags: ubuntu=(10.04|11.10){kernel:3.0.0-12-(generic|server)}
 Rank: 1


### PR DESCRIPTION
Fixes #92