### PR TITLE
fix seccomp check

### DIFF
--- a/linux-exploit-suggester.sh
+++ b/linux-exploit-suggester.sh
@@ -1781,7 +1781,7 @@ EOF
 FEATURES[((n++))]=$(cat <<EOF
 feature: Syscalls filtering
 available: CONFIG_SECCOMP=y
-enabled: cmd:grep -i Seccomp /proc/self/status | awk '{print \$2}'
+enabled: cmd:grep -iw Seccomp /proc/self/status | awk '{print \$2}'
 analysis-url: https://github.com/mzet-/les-res/blob/master/features/bpf_syscall.md
 EOF
 )
@@ -2179,8 +2179,9 @@ for FEATURE in "${FEATURES[@]}"; do
 
     feature=$(echo "$FEATURE" | grep "feature: " | cut -d' ' -f 2-)
 
-	if [ -n "$cmdStdout" ]; then
-        if [ "$cmdStdout" -eq 0 ]; then
+    if [ -n "$cmdStdout" ]; then
+echo "cmdStdout=\"$cmdStdout\""
+        if [ $cmdStdout -eq 0 ]; then
             state="[ ${txtred}Set to $cmdStdout${txtrst} ]"
 			cmdStdout=""
         else
@@ -2193,15 +2194,15 @@ for FEATURE in "${FEATURES[@]}"; do
 
 	# for 3rd party (3) mode display "N/A" or "Enabled"
 	if [ $MODE -eq 3 ]; then
-        enabled="[ ${txtgrn}Enabled${txtrst}   ]"
-        disabled="[   ${txtgray}N/A${txtrst}    ]"
+            enabled="[ ${txtgrn}Enabled${txtrst}   ]"
+            disabled="[   ${txtgray}N/A${txtrst}    ]"
 
-    # for attack-surface (4) mode display "Locked" or "Exposed"
-    elif [ $MODE -eq 4 ]; then
-       enabled="[ ${txtred}Exposed${txtrst}  ]"
-       disabled="[ ${txtgrn}Locked${txtrst}   ]"
+        # for attack-surface (4) mode display "Locked" or "Exposed"
+        elif [ $MODE -eq 4 ]; then
+           enabled="[ ${txtred}Exposed${txtrst}  ]"
+           disabled="[ ${txtgrn}Locked${txtrst}   ]"
 
-	#other modes" "Disabled" / "Enabled"
+	# other modes" "Disabled" / "Enabled"
 	else
 		enabled="[ ${txtgrn}Enabled${txtrst}  ]"
 		disabled="[ ${txtred}Disabled${txtrst} ]"


### PR DESCRIPTION
fixes a bug when checking seccomp:
```
grep -i Seccomp /proc/self/status
Seccomp:	0
Seccomp_filters:	0
```
which results in "0\n0" hence -eq 0 comparison fails and seccomp is not checked correctly.

also fixed formatting.